### PR TITLE
feat: Add dashboard filter support with card dependency tracking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         args: [--fix=lf]
       - id: name-tests-test
         args: [--pytest-test-first]
-        exclude: ^tests/(conftest|fixtures|__init__)\.py$
+        exclude: ^tests/(conftest|__init__|fixtures/.*)\.py$
 
   # Python code formatting with black
   - repo: https://github.com/psf/black

--- a/export_metabase.py
+++ b/export_metabase.py
@@ -459,6 +459,19 @@ class MetabaseExporter:
                     if dashcard.get("card_id"):
                         card_ids.append(dashcard["card_id"])
 
+            # Extract card IDs from dashboard parameters (filters with values from cards)
+            if dashboard_data.get("parameters"):
+                for param in dashboard_data["parameters"]:
+                    if "values_source_config" in param and isinstance(
+                        param["values_source_config"], dict
+                    ):
+                        source_card_id = param["values_source_config"].get("card_id")
+                        if source_card_id and source_card_id not in card_ids:
+                            card_ids.append(source_card_id)
+                            logger.info(
+                                f"     Dashboard parameter '{param.get('name')}' references card {source_card_id} - will be exported as dependency"
+                            )
+
             dashboard_obj = Dashboard(
                 id=dashboard_id,
                 name=dashboard_data["name"],

--- a/import_metabase.py
+++ b/import_metabase.py
@@ -984,11 +984,15 @@ class MetabaseImporter:
                                     f"Remapped parameter card_id {source_card_id} -> {self._card_map[source_card_id]}"
                                 )
                             else:
-                                # Card not found, skip this parameter
+                                # Card not found, remove values_source_config but keep the parameter
                                 logger.warning(
-                                    f"Skipping dashboard parameter '{param.get('name')}' - references missing card {source_card_id}"
+                                    f"Dashboard parameter '{param.get('name')}' references missing card {source_card_id}. "
+                                    f"Importing parameter without values_source_config (filter values won't be populated from card)."
                                 )
-                                continue
+                                # Remove the values_source_config to avoid API errors
+                                del param_copy["values_source_config"]
+                                if "values_source_type" in param_copy:
+                                    del param_copy["values_source_type"]
                     remapped_parameters.append(param_copy)
 
                 # 4. Create dashboard with basic info first

--- a/tests/fixtures/sample_responses.py
+++ b/tests/fixtures/sample_responses.py
@@ -116,6 +116,101 @@ SAMPLE_DASHBOARD = {
     "creator_id": 1,
 }
 
+# Dashboard with comprehensive filter examples
+SAMPLE_DASHBOARD_WITH_FILTERS = {
+    "id": 201,
+    "name": "Sales Dashboard with Filters",
+    "description": "Dashboard demonstrating various filter types and mappings",
+    "collection_id": 1,
+    "parameters": [
+        {
+            "id": "date_filter",
+            "name": "Date Range",
+            "slug": "date_range",
+            "type": "date/range",
+            "default": None,
+        },
+        {
+            "id": "category_filter",
+            "name": "Product Category",
+            "slug": "category",
+            "type": "string/=",
+            "default": "Electronics",
+            "values_source_type": "card",
+            "values_source_config": {
+                "card_id": 100,
+                "value_field": ["field", 10, None],
+            },
+        },
+        {
+            "id": "region_filter",
+            "name": "Region",
+            "slug": "region",
+            "type": "string/=",
+            "default": None,
+        },
+    ],
+    "dashcards": [
+        {
+            "id": 10,
+            "card_id": 100,
+            "dashboard_id": 201,
+            "size_x": 8,
+            "size_y": 6,
+            "row": 0,
+            "col": 0,
+            "parameter_mappings": [
+                {
+                    "parameter_id": "date_filter",
+                    "card_id": 100,
+                    "target": ["dimension", ["field", 3, {"temporal-unit": "month"}]],
+                },
+                {
+                    "parameter_id": "category_filter",
+                    "card_id": 100,
+                    "target": ["dimension", ["field", 10, None]],
+                },
+            ],
+            "visualization_settings": {
+                "graph.dimensions": ["created_at"],
+                "graph.metrics": ["sum"],
+            },
+        },
+        {
+            "id": 11,
+            "card_id": 101,
+            "dashboard_id": 201,
+            "size_x": 8,
+            "size_y": 6,
+            "row": 0,
+            "col": 8,
+            "parameter_mappings": [
+                {
+                    "parameter_id": "date_filter",
+                    "card_id": 101,
+                    "target": [
+                        "dimension",
+                        ["field", "created_at", {"base-type": "type/DateTime"}],
+                    ],
+                },
+                {
+                    "parameter_id": "region_filter",
+                    "card_id": 101,
+                    "target": ["dimension", ["field", 15, None]],
+                },
+            ],
+            "visualization_settings": {},
+        },
+    ],
+    "archived": False,
+    "enable_embedding": False,
+    "embedding_params": None,
+    "cache_ttl": None,
+    "created_at": "2025-01-10T10:00:00.000Z",
+    "updated_at": "2025-01-26T14:30:00.000Z",
+    "creator_id": 1,
+}
+
 SAMPLE_COLLECTIONS_TREE = [
     {
         "id": "root",

--- a/tests/test_dashboard_filters.py
+++ b/tests/test_dashboard_filters.py
@@ -1,0 +1,355 @@
+"""Tests for dashboard filter export and import functionality.
+
+This module tests that dashboard filters (parameters) and their mappings
+are correctly preserved during the export and import process.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from export_metabase import MetabaseExporter
+from import_metabase import MetabaseImporter
+from lib.config import ExportConfig, ImportConfig
+from lib.models import Dashboard, Manifest, ManifestMeta
+from lib.utils import read_json_file, write_json_file
+from tests.fixtures.sample_responses import SAMPLE_DASHBOARD_WITH_FILTERS
+
+
+class TestDashboardFilterExport:
+    """Test suite for exporting dashboards with filters."""
+
+    def test_export_dashboard_preserves_parameters(self, tmp_path):
+        """Test that dashboard parameters (filters) are exported."""
+        config = ExportConfig(
+            source_url="https://source.example.com",
+            export_dir=str(tmp_path / "export"),
+            include_dashboards=True,
+        )
+
+        with patch("export_metabase.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_dashboard.return_value = SAMPLE_DASHBOARD_WITH_FILTERS
+            mock_client_class.return_value = mock_client
+
+            exporter = MetabaseExporter(config)
+            exporter._export_dashboard(201, "collections/test")
+
+            # Verify dashboard was exported
+            exported_files = list(
+                (tmp_path / "export" / "collections" / "test" / "dashboards").glob("*.json")
+            )
+            assert len(exported_files) == 1
+
+            # Read exported dashboard
+            exported_data = read_json_file(exported_files[0])
+
+            # Verify parameters are preserved
+            assert "parameters" in exported_data
+            assert len(exported_data["parameters"]) == 3
+
+            # Verify parameter details
+            date_param = next(p for p in exported_data["parameters"] if p["id"] == "date_filter")
+            assert date_param["name"] == "Date Range"
+            assert date_param["type"] == "date/range"
+
+            category_param = next(
+                p for p in exported_data["parameters"] if p["id"] == "category_filter"
+            )
+            assert category_param["name"] == "Product Category"
+            assert category_param["type"] == "string/="
+            assert category_param["default"] == "Electronics"
+            assert "values_source_config" in category_param
+            assert category_param["values_source_config"]["card_id"] == 100
+
+    def test_export_dashboard_preserves_parameter_mappings(self, tmp_path):
+        """Test that dashcard parameter mappings are exported."""
+        config = ExportConfig(
+            source_url="https://source.example.com",
+            export_dir=str(tmp_path / "export"),
+            include_dashboards=True,
+        )
+
+        with patch("export_metabase.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_dashboard.return_value = SAMPLE_DASHBOARD_WITH_FILTERS
+            mock_client_class.return_value = mock_client
+
+            exporter = MetabaseExporter(config)
+            exporter._export_dashboard(201, "collections/test")
+
+            # Read exported dashboard
+            exported_files = list(
+                (tmp_path / "export" / "collections" / "test" / "dashboards").glob("*.json")
+            )
+            exported_data = read_json_file(exported_files[0])
+
+            # Verify dashcards have parameter_mappings
+            assert "dashcards" in exported_data
+            assert len(exported_data["dashcards"]) == 2
+
+            # Check first dashcard mappings
+            dashcard1 = exported_data["dashcards"][0]
+            assert "parameter_mappings" in dashcard1
+            assert len(dashcard1["parameter_mappings"]) == 2
+
+            # Verify mapping structure
+            date_mapping = next(
+                m for m in dashcard1["parameter_mappings"] if m["parameter_id"] == "date_filter"
+            )
+            assert date_mapping["card_id"] == 100
+            assert "target" in date_mapping
+
+            # Check second dashcard mappings
+            dashcard2 = exported_data["dashcards"][1]
+            assert len(dashcard2["parameter_mappings"]) == 2
+
+
+class TestDashboardFilterImport:
+    """Test suite for importing dashboards with filters."""
+
+    @pytest.fixture
+    def setup_import_test(self, tmp_path):
+        """Set up test environment for import tests."""
+        export_dir = tmp_path / "export"
+        export_dir.mkdir()
+
+        # Create manifest
+        manifest = Manifest(
+            meta=ManifestMeta(
+                source_url="https://source.example.com",
+                export_timestamp="2025-10-21T12:00:00.000000",
+                tool_version="1.0.0",
+                cli_args={},
+            ),
+            databases={2: "Production Database"},
+            collections=[],
+            cards=[],
+            dashboards=[
+                Dashboard(
+                    id=201,
+                    name="Sales Dashboard with Filters",
+                    collection_id=1,
+                    ordered_cards=[100, 101],
+                    file_path="collections/test/dashboards/dash_201_sales.json",
+                    checksum="abc123",
+                )
+            ],
+        )
+
+        # Write manifest
+        write_json_file(manifest, export_dir / "manifest.json")
+
+        # Write dashboard file
+        dash_dir = export_dir / "collections" / "test" / "dashboards"
+        dash_dir.mkdir(parents=True)
+        write_json_file(SAMPLE_DASHBOARD_WITH_FILTERS, dash_dir / "dash_201_sales.json")
+
+        # Create db_map
+        db_map = {"by_id": {"2": 20}, "by_name": {"Production Database": 20}}
+        db_map_path = tmp_path / "db_map.json"
+        write_json_file(db_map, db_map_path)
+
+        return {
+            "export_dir": export_dir,
+            "db_map_path": db_map_path,
+            "tmp_path": tmp_path,
+        }
+
+    def test_import_dashboard_preserves_parameters(self, setup_import_test):
+        """Test that dashboard parameters are preserved during import."""
+        config = ImportConfig(
+            target_url="https://target.example.com",
+            export_dir=str(setup_import_test["export_dir"]),
+            db_map_path=str(setup_import_test["db_map_path"]),
+            dry_run=False,
+        )
+
+        with patch("import_metabase.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_collections_tree.return_value = []
+
+            # Mock create_dashboard to capture the payload
+            created_dashboard = {"id": 301, "name": "Sales Dashboard with Filters"}
+            mock_client.create_dashboard.return_value = created_dashboard
+            mock_client.update_dashboard.return_value = created_dashboard
+
+            mock_client_class.return_value = mock_client
+
+            importer = MetabaseImporter(config)
+            # Load manifest
+            importer._load_export_package()
+            importer._collection_map = {1: 10}  # Map source collection to target
+            importer._card_map = {100: 200, 101: 201}  # Map source cards to target
+
+            # Import dashboards
+            importer._import_dashboards()
+
+            # Verify create_dashboard was called with parameters
+            assert mock_client.create_dashboard.called
+            create_payload = mock_client.create_dashboard.call_args[0][0]
+
+            assert "parameters" in create_payload
+            assert len(create_payload["parameters"]) == 3
+
+            # Verify date filter
+            date_param = next(p for p in create_payload["parameters"] if p["id"] == "date_filter")
+            assert date_param["name"] == "Date Range"
+            assert date_param["type"] == "date/range"
+
+            # Verify category filter with remapped card_id
+            category_param = next(
+                p for p in create_payload["parameters"] if p["id"] == "category_filter"
+            )
+            assert category_param["values_source_config"]["card_id"] == 200  # Remapped from 100
+
+    def test_import_dashboard_remaps_parameter_mapping_card_ids(self, setup_import_test):
+        """Test that card IDs in parameter mappings are remapped during import."""
+        config = ImportConfig(
+            target_url="https://target.example.com",
+            export_dir=str(setup_import_test["export_dir"]),
+            db_map_path=str(setup_import_test["db_map_path"]),
+            dry_run=False,
+        )
+
+        with patch("import_metabase.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_collections_tree.return_value = []
+
+            created_dashboard = {"id": 301, "name": "Sales Dashboard with Filters"}
+            mock_client.create_dashboard.return_value = created_dashboard
+            mock_client.update_dashboard.return_value = created_dashboard
+
+            mock_client_class.return_value = mock_client
+
+            importer = MetabaseImporter(config)
+            importer._load_export_package()
+            importer._collection_map = {1: 10}
+            importer._card_map = {100: 200, 101: 201}
+
+            # Import dashboards
+            importer._import_dashboards()
+
+            # Verify update_dashboard was called with remapped parameter_mappings
+            assert mock_client.update_dashboard.called
+            update_payload = mock_client.update_dashboard.call_args[0][1]
+
+            assert "dashcards" in update_payload
+            dashcards = update_payload["dashcards"]
+            assert len(dashcards) == 2
+
+            # Check first dashcard - card_id should be remapped
+            dashcard1 = dashcards[0]
+            assert dashcard1["card_id"] == 200  # Remapped from 100
+
+            # Check parameter_mappings in first dashcard
+            assert "parameter_mappings" in dashcard1
+            mappings1 = dashcard1["parameter_mappings"]
+            assert len(mappings1) == 2
+
+            # Verify card_id in parameter_mappings is remapped
+            for mapping in mappings1:
+                assert mapping["card_id"] == 200  # All should be remapped to 200
+
+            # Check second dashcard
+            dashcard2 = dashcards[1]
+            assert dashcard2["card_id"] == 201  # Remapped from 101
+
+            mappings2 = dashcard2["parameter_mappings"]
+            for mapping in mappings2:
+                assert mapping["card_id"] == 201  # All should be remapped to 201
+
+    def test_import_dashboard_preserves_filter_dependencies(self, setup_import_test):
+        """Test that filter dependencies and relationships are maintained."""
+        config = ImportConfig(
+            target_url="https://target.example.com",
+            export_dir=str(setup_import_test["export_dir"]),
+            db_map_path=str(setup_import_test["db_map_path"]),
+            dry_run=False,
+        )
+
+        with patch("import_metabase.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_collections_tree.return_value = []
+
+            created_dashboard = {"id": 301, "name": "Sales Dashboard with Filters"}
+            mock_client.create_dashboard.return_value = created_dashboard
+            mock_client.update_dashboard.return_value = created_dashboard
+
+            mock_client_class.return_value = mock_client
+
+            importer = MetabaseImporter(config)
+            importer._load_export_package()
+            importer._collection_map = {1: 10}
+            importer._card_map = {100: 200, 101: 201}
+
+            # Import dashboards
+            importer._import_dashboards()
+
+            # Verify parameter relationships are preserved
+            update_payload = mock_client.update_dashboard.call_args[0][1]
+            dashcards = update_payload["dashcards"]
+
+            # Verify that parameter_id references match between parameters and mappings
+            create_payload = mock_client.create_dashboard.call_args[0][0]
+            parameter_ids = {p["id"] for p in create_payload["parameters"]}
+
+            for dashcard in dashcards:
+                for mapping in dashcard.get("parameter_mappings", []):
+                    # Each mapping should reference a valid parameter
+                    assert mapping["parameter_id"] in parameter_ids
+                    # Target field structure should be preserved
+                    assert "target" in mapping
+                    assert isinstance(mapping["target"], list)
+
+    def test_import_dashboard_with_missing_parameter_card(self, setup_import_test):
+        """Test that parameters are still imported even if referenced card is missing."""
+        config = ImportConfig(
+            target_url="https://target.example.com",
+            export_dir=str(setup_import_test["export_dir"]),
+            db_map_path=str(setup_import_test["db_map_path"]),
+            dry_run=False,
+        )
+
+        with patch("import_metabase.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_collections_tree.return_value = []
+
+            created_dashboard = {"id": 301, "name": "Sales Dashboard with Filters"}
+            mock_client.create_dashboard.return_value = created_dashboard
+            mock_client.update_dashboard.return_value = created_dashboard
+
+            mock_client_class.return_value = mock_client
+
+            importer = MetabaseImporter(config)
+            importer._load_export_package()
+            importer._collection_map = {1: 10}
+            # Card 100 is NOT in the map (simulating missing card)
+            importer._card_map = {101: 201}
+
+            # Import dashboards
+            importer._import_dashboards()
+
+            # Verify create_dashboard was called
+            create_payload = mock_client.create_dashboard.call_args[0][0]
+            assert "parameters" in create_payload
+
+            # The category parameter should still be imported, but without values_source_config
+            category_param = next(
+                (p for p in create_payload["parameters"] if p["id"] == "category_filter"), None
+            )
+            assert (
+                category_param is not None
+            ), "Parameter should be imported even if card is missing"
+            assert (
+                "values_source_config" not in category_param
+            ), "values_source_config should be removed"
+            assert (
+                "values_source_type" not in category_param
+            ), "values_source_type should be removed"
+
+            # Other parameters without dependencies should still be there
+            date_param = next(
+                (p for p in create_payload["parameters"] if p["id"] == "date_filter"), None
+            )
+            assert date_param is not None


### PR DESCRIPTION
## Summary

This PR adds comprehensive support for dashboard filters (parameters) with proper card dependency tracking during export and import operations.

## Changes

### Export Improvements
- Extract card IDs from dashboard parameter `values_source_config` to ensure filter dependencies are exported
- Log when dashboard parameters reference cards that will be exported as dependencies

### Import Improvements
- Remap card IDs in parameter `values_source_config` during import to match new target card IDs
- Handle missing cards gracefully by removing `values_source_config` and `values_source_type` instead of skipping the entire parameter
- This allows filters to be imported even if their source cards are missing, maintaining dashboard structure

### Testing
- Added comprehensive test suite with 6 new tests covering:
  - Export of dashboard parameters and parameter mappings
  - Import with parameter preservation and card ID remapping
  - Filter dependency relationships
  - Graceful handling of missing parameter cards
- All tests pass successfully (207 unit tests passing)

### Configuration
- Fixed pre-commit config to properly exclude fixtures directory from test naming checks

## Testing

All unit tests pass:
```
207 passed, 11 skipped, 10 errors (integration tests requiring Docker)
```

New tests specifically for dashboard filters:
- `test_export_dashboard_preserves_parameters`
- `test_export_dashboard_preserves_parameter_mappings`
- `test_import_dashboard_preserves_parameters`
- `test_import_dashboard_remaps_parameter_mapping_card_ids`
- `test_import_dashboard_preserves_filter_dependencies`
- `test_import_dashboard_with_missing_parameter_card`

## Impact

This change ensures that dashboard filters work correctly after migration, including:
- Date range filters
- Category filters with values from cards
- Parameter mappings to dashboard cards
- Proper card ID remapping in the target environment

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author