### PR TITLE
fix: remap field IDs in dimension-type template tags during import

### DIFF
--- a/lib/remapping/query_remapper.py
+++ b/lib/remapping/query_remapper.py
@@ -159,7 +159,9 @@ class QueryRemapper:
                 self._remap_joins(inner_query, source_db_id)
                 self._remap_query_clauses(inner_query, source_db_id)
 
-    def _remap_native_query_in_place(self, dataset_query: dict[str, Any], source_db_id: int) -> None:
+    def _remap_native_query_in_place(
+        self, dataset_query: dict[str, Any], source_db_id: int
+    ) -> None:
         """Remaps native query card references in place.
 
         Args:
@@ -719,7 +721,9 @@ class QueryRemapper:
 
         return re.sub(NATIVE_CARD_REF_FULL_PATTERN, replace_card_ref, sql)
 
-    def _remap_template_tags(self, template_tags: dict[str, Any], source_db_id: int = 0) -> dict[str, Any]:
+    def _remap_template_tags(
+        self, template_tags: dict[str, Any], source_db_id: int = 0
+    ) -> dict[str, Any]:
         """Remaps card and dimension references in template-tags.
 
         Updates both the tag names and the card-id values for card-type tags,
@@ -785,9 +789,7 @@ class QueryRemapper:
                     tag_data_copy = copy.deepcopy(tag_data)
                     tag_data_copy["dimension"] = self._remap_list(dimension, source_db_id)
                     remapped_tags[tag_name] = tag_data_copy
-                    logger.debug(
-                        f"Remapped dimension template tag '{tag_name}' field reference"
-                    )
+                    logger.debug(f"Remapped dimension template tag '{tag_name}' field reference")
                     continue
 
             # Non-card/non-dimension tags or unmapped card tags - keep as-is

--- a/lib/remapping/query_remapper.py
+++ b/lib/remapping/query_remapper.py
@@ -90,7 +90,7 @@ class QueryRemapper:
 
         if is_native_query:
             # Remap native query card references (SQL and template-tags)
-            self._remap_native_query_in_place(query)
+            self._remap_native_query_in_place(query, source_db_id)
         else:
             # Remap MBQL query (source-table, joins, field IDs)
             self._remap_mbql_query(query, source_db_id)
@@ -159,19 +159,20 @@ class QueryRemapper:
                 self._remap_joins(inner_query, source_db_id)
                 self._remap_query_clauses(inner_query, source_db_id)
 
-    def _remap_native_query_in_place(self, dataset_query: dict[str, Any]) -> None:
+    def _remap_native_query_in_place(self, dataset_query: dict[str, Any], source_db_id: int) -> None:
         """Remaps native query card references in place.
 
         Args:
             dataset_query: The dataset_query dictionary to modify in place.
+            source_db_id: The source database ID for field lookups.
         """
         # Check query format (v57 uses lib/type and stages, v56 uses type)
         if LIB_TYPE_KEY in dataset_query or STAGES_KEY in dataset_query:
             # v57 MBQL 5 format with stages
-            self._remap_native_query_v57(dataset_query)
+            self._remap_native_query_v57(dataset_query, source_db_id)
         else:
             # v56 MBQL 4 format
-            self._remap_native_query_v56(dataset_query)
+            self._remap_native_query_v56(dataset_query, source_db_id)
 
     def _remap_card_table_id(self, data: dict[str, Any], source_db_id: int) -> None:
         """Remaps the table_id field at the card level."""
@@ -595,6 +596,7 @@ class QueryRemapper:
         Handles both v56 (MBQL 4) and v57 (MBQL 5) query formats:
         - SQL query text: {{#123-model-name}} -> {{#456-model-name}}
         - Template tags with type "card": card-id remapping
+        - Template tags with type "dimension": field ID remapping
 
         Args:
             card_data: The card data dictionary with dataset_query.
@@ -604,18 +606,19 @@ class QueryRemapper:
         """
         data = copy.deepcopy(card_data)
         dataset_query = data.get("dataset_query", {})
+        source_db_id = data.get("database_id") or dataset_query.get("database") or 0
 
         # Check query format (v57 uses lib/type and stages, v56 uses type)
         if LIB_TYPE_KEY in dataset_query:
             # v57 MBQL 5 format with stages
-            self._remap_native_query_v57(dataset_query)
+            self._remap_native_query_v57(dataset_query, source_db_id)
         else:
             # v56 MBQL 4 format
-            self._remap_native_query_v56(dataset_query)
+            self._remap_native_query_v56(dataset_query, source_db_id)
 
         return data
 
-    def _remap_native_query_v56(self, dataset_query: dict[str, Any]) -> None:
+    def _remap_native_query_v56(self, dataset_query: dict[str, Any], source_db_id: int) -> None:
         """Remaps native query card references in v56 (MBQL 4) format.
 
         v56 structure:
@@ -644,9 +647,9 @@ class QueryRemapper:
         # Remap template-tags
         template_tags = native.get(TEMPLATE_TAGS_KEY)
         if isinstance(template_tags, dict):
-            native[TEMPLATE_TAGS_KEY] = self._remap_template_tags(template_tags)
+            native[TEMPLATE_TAGS_KEY] = self._remap_template_tags(template_tags, source_db_id)
 
-    def _remap_native_query_v57(self, dataset_query: dict[str, Any]) -> None:
+    def _remap_native_query_v57(self, dataset_query: dict[str, Any], source_db_id: int) -> None:
         """Remaps native query card references in v57 (MBQL 5) format.
 
         v57 structure:
@@ -682,7 +685,7 @@ class QueryRemapper:
             # Remap template-tags at stage level
             template_tags = stage.get(TEMPLATE_TAGS_KEY)
             if isinstance(template_tags, dict):
-                stage[TEMPLATE_TAGS_KEY] = self._remap_template_tags(template_tags)
+                stage[TEMPLATE_TAGS_KEY] = self._remap_template_tags(template_tags, source_db_id)
 
     def _remap_sql_card_references(self, sql: str) -> str:
         """Remaps card references in a SQL query string.
@@ -716,13 +719,15 @@ class QueryRemapper:
 
         return re.sub(NATIVE_CARD_REF_FULL_PATTERN, replace_card_ref, sql)
 
-    def _remap_template_tags(self, template_tags: dict[str, Any]) -> dict[str, Any]:
-        """Remaps card references in template-tags.
+    def _remap_template_tags(self, template_tags: dict[str, Any], source_db_id: int = 0) -> dict[str, Any]:
+        """Remaps card and dimension references in template-tags.
 
-        Updates both the tag names and the card-id values for card-type tags.
+        Updates both the tag names and the card-id values for card-type tags,
+        and remaps field IDs in dimension-type tags.
 
         Args:
             template_tags: The template-tags dictionary.
+            source_db_id: The source database ID for field lookups.
 
         Returns:
             A new dictionary with remapped template tags.
@@ -773,7 +778,19 @@ class QueryRemapper:
                             f"with card-id {source_card_id}. Keeping original."
                         )
 
-            # Non-card tags or unmapped card tags - keep as-is
+            elif tag_data.get("type") == "dimension":
+                # Handle dimension-type template tags with field references
+                dimension = tag_data.get("dimension")
+                if isinstance(dimension, list):
+                    tag_data_copy = copy.deepcopy(tag_data)
+                    tag_data_copy["dimension"] = self._remap_list(dimension, source_db_id)
+                    remapped_tags[tag_name] = tag_data_copy
+                    logger.debug(
+                        f"Remapped dimension template tag '{tag_name}' field reference"
+                    )
+                    continue
+
+            # Non-card/non-dimension tags or unmapped card tags - keep as-is
             remapped_tags[tag_name] = tag_data
 
         return remapped_tags

--- a/tests/test_native_query_remapping.py
+++ b/tests/test_native_query_remapping.py
@@ -894,6 +894,269 @@ class TestQueryRemapperV57Advanced:
         assert result["dataset_query"]["stages"][0]["expressions"][0][2][1] == 10200
 
 
+class TestDimensionTemplateTagRemapping:
+    """Tests for dimension-type template-tag field ID remapping.
+
+    Dimension-type template tags contain field references like
+    ["field", field_id, null] (v56) or ["field", {metadata}, field_id] (v57)
+    that need to be remapped during import.
+
+    See: https://github.com/Finverity/metabase-migration-toolkit/issues/56
+    """
+
+    @pytest.fixture
+    def id_mapper(self):
+        """Create an ID mapper with db, card, and field mappings."""
+        mapper = create_test_id_mapper(
+            db_mapping={1: 100},
+            card_mapping={50: 500},
+        )
+        # Add field mappings keyed by (source_db_id, source_field_id)
+        mapper._field_map[(1, 3000)] = 9000
+        mapper._field_map[(1, 3001)] = 9001
+        return mapper
+
+    @pytest.fixture
+    def remapper(self, id_mapper):
+        """Create a query remapper."""
+        return QueryRemapper(id_mapper)
+
+    def test_remap_v57_dimension_template_tag_field_id(self, remapper):
+        """Test that a v57 dimension template-tag has its field ID remapped."""
+        card_data = {
+            "database_id": 1,
+            "dataset_query": {
+                "lib/type": "mbql/query",
+                "database": 1,
+                "stages": [
+                    {
+                        "lib/type": "mbql.stage/native",
+                        "native": "SELECT * FROM venues [[AND {{venue_type_label}}]]",
+                        "template-tags": {
+                            "venue_type_label": {
+                                "type": "dimension",
+                                "name": "venue_type_label",
+                                "id": "abc-123",
+                                "display-name": "Venue Type Label",
+                                "widget-type": "category",
+                                "dimension": [
+                                    "field",
+                                    {"base-type": "type/Text", "lib/uuid": "uuid-1"},
+                                    3000,
+                                ],
+                            }
+                        },
+                    }
+                ],
+            },
+        }
+
+        result, success = remapper.remap_card_data(card_data)
+
+        assert success
+        stage = result["dataset_query"]["stages"][0]
+        tag = stage["template-tags"]["venue_type_label"]
+        # The field ID in the dimension array should be remapped
+        assert tag["dimension"][2] == 9000
+
+    def test_remap_v57_dimension_template_tag_without_base_type(self, remapper):
+        """Test dimension tags with only lib/uuid in metadata dict."""
+        card_data = {
+            "database_id": 1,
+            "dataset_query": {
+                "lib/type": "mbql/query",
+                "database": 1,
+                "stages": [
+                    {
+                        "lib/type": "mbql.stage/native",
+                        "native": "SELECT * FROM venues [[AND {{venue_region}}]]",
+                        "template-tags": {
+                            "venue_region": {
+                                "type": "dimension",
+                                "name": "venue_region",
+                                "id": "def-456",
+                                "display-name": "Venue Region",
+                                "widget-type": "category",
+                                "dimension": [
+                                    "field",
+                                    {"lib/uuid": "uuid-2"},
+                                    3001,
+                                ],
+                            }
+                        },
+                    }
+                ],
+            },
+        }
+
+        result, success = remapper.remap_card_data(card_data)
+
+        assert success
+        stage = result["dataset_query"]["stages"][0]
+        tag = stage["template-tags"]["venue_region"]
+        assert tag["dimension"][2] == 9001
+
+    def test_remap_v57_dimension_tag_preserves_non_dimension_fields(self, remapper):
+        """Test that other fields in a dimension tag are preserved unchanged."""
+        card_data = {
+            "database_id": 1,
+            "dataset_query": {
+                "lib/type": "mbql/query",
+                "database": 1,
+                "stages": [
+                    {
+                        "lib/type": "mbql.stage/native",
+                        "native": "SELECT * FROM venues [[AND {{venue_type_label}}]]",
+                        "template-tags": {
+                            "venue_type_label": {
+                                "type": "dimension",
+                                "name": "venue_type_label",
+                                "id": "abc-123",
+                                "display-name": "Venue Type Label",
+                                "widget-type": "category",
+                                "dimension": [
+                                    "field",
+                                    {"base-type": "type/Text", "lib/uuid": "uuid-1"},
+                                    3000,
+                                ],
+                            }
+                        },
+                    }
+                ],
+            },
+        }
+
+        result, success = remapper.remap_card_data(card_data)
+
+        assert success
+        stage = result["dataset_query"]["stages"][0]
+        tag = stage["template-tags"]["venue_type_label"]
+        # Non-dimension fields must be preserved
+        assert tag["type"] == "dimension"
+        assert tag["name"] == "venue_type_label"
+        assert tag["id"] == "abc-123"
+        assert tag["display-name"] == "Venue Type Label"
+        assert tag["widget-type"] == "category"
+
+    def test_remap_v57_full_native_query_with_dimension_tags(self, remapper):
+        """End-to-end test: v57 native query with both card and dimension tags."""
+        card_data = {
+            "database_id": 1,
+            "dataset_query": {
+                "lib/type": "mbql/query",
+                "database": 1,
+                "stages": [
+                    {
+                        "lib/type": "mbql.stage/native",
+                        "native": "SELECT * FROM {{#50-my-model}} [[AND {{venue_type_label}}]]",
+                        "template-tags": {
+                            "#50-my-model": {
+                                "type": "card",
+                                "card-id": 50,
+                                "name": "#50-my-model",
+                                "display-name": "#50 My Model",
+                                "id": "card-tag-uuid",
+                            },
+                            "venue_type_label": {
+                                "type": "dimension",
+                                "name": "venue_type_label",
+                                "id": "dim-tag-uuid",
+                                "display-name": "Venue Type Label",
+                                "widget-type": "category",
+                                "dimension": [
+                                    "field",
+                                    {"base-type": "type/Text", "lib/uuid": "uuid-1"},
+                                    3000,
+                                ],
+                            },
+                        },
+                    }
+                ],
+            },
+        }
+
+        result, success = remapper.remap_card_data(card_data)
+
+        assert success
+        stage = result["dataset_query"]["stages"][0]
+
+        # Card-type tag should be remapped
+        assert "#500-my-model" in stage["template-tags"]
+        assert stage["template-tags"]["#500-my-model"]["card-id"] == 500
+
+        # Dimension-type tag should have its field ID remapped
+        dim_tag = stage["template-tags"]["venue_type_label"]
+        assert dim_tag["dimension"][2] == 9000
+
+    def test_remap_v56_dimension_template_tag(self, remapper):
+        """Test that v56-format dimension tags are remapped correctly."""
+        card_data = {
+            "database_id": 1,
+            "dataset_query": {
+                "type": "native",
+                "database": 1,
+                "native": {
+                    "query": "SELECT * FROM venues [[AND {{venue_type_label}}]]",
+                    "template-tags": {
+                        "venue_type_label": {
+                            "type": "dimension",
+                            "name": "venue_type_label",
+                            "id": "abc-123",
+                            "display-name": "Venue Type Label",
+                            "widget-type": "category",
+                            "dimension": ["field", 3000, None],
+                        }
+                    },
+                },
+            },
+        }
+
+        result, success = remapper.remap_card_data(card_data)
+
+        assert success
+        tag = result["dataset_query"]["native"]["template-tags"]["venue_type_label"]
+        # v56 format: ["field", field_id, options] — field_id at index 1
+        assert tag["dimension"][1] == 9000
+
+    def test_remap_dimension_tag_unmapped_field(self, remapper):
+        """Test graceful degradation when a field ID has no mapping."""
+        card_data = {
+            "database_id": 1,
+            "dataset_query": {
+                "lib/type": "mbql/query",
+                "database": 1,
+                "stages": [
+                    {
+                        "lib/type": "mbql.stage/native",
+                        "native": "SELECT * FROM venues [[AND {{unknown_field}}]]",
+                        "template-tags": {
+                            "unknown_field": {
+                                "type": "dimension",
+                                "name": "unknown_field",
+                                "id": "xyz-789",
+                                "display-name": "Unknown Field",
+                                "widget-type": "category",
+                                "dimension": [
+                                    "field",
+                                    {"base-type": "type/Integer", "lib/uuid": "uuid-3"},
+                                    99999,  # Not in field map
+                                ],
+                            }
+                        },
+                    }
+                ],
+            },
+        }
+
+        result, success = remapper.remap_card_data(card_data)
+
+        assert success
+        stage = result["dataset_query"]["stages"][0]
+        tag = stage["template-tags"]["unknown_field"]
+        # Unmapped field should be preserved with original ID
+        assert tag["dimension"][2] == 99999
+
+
 class TestQueryRemapperEdgeCases:
     """Tests for edge cases in query remapping."""
 


### PR DESCRIPTION
## Summary

- **Fix dimension-type template-tag field IDs not being remapped** during native query card import, causing Metabase API 400 errors
- **Thread `source_db_id`** through the native query remapping call chain (`remap_card_data` → `_remap_native_query_in_place` → `_remap_native_query_v56`/`v57` → `_remap_template_tags`)
- **Add `elif "dimension"` branch** in `_remap_template_tags()` that calls the existing `_remap_list()` on the dimension's field reference array

## Root Cause

`_remap_template_tags()` in `query_remapper.py` only handled `"type": "card"` tags. Dimension-type tags (field filter variables like `{{venue_type_label}}`) fell through to the default case and were returned with their original source-instance field IDs unchanged. The Metabase API then rejected the card with a 400 error because the field IDs belonged to the wrong database.

## Changes

| File | Changes |
|------|---------|
| `lib/remapping/query_remapper.py` | Thread `source_db_id` through 5 method signatures; add `elif "dimension"` branch in `_remap_template_tags()` |
| `tests/test_native_query_remapping.py` | Add 6 new tests for dimension template-tag remapping (v57, v56, mixed, unmapped field graceful degradation) |

## Test plan

- [x] Wrote failing tests first (TDD) — 4 tests failed confirming the bug exists
- [x] Implemented the fix — all 47 tests pass (6 new + 41 existing, zero regressions)
- [ ] CI passes on this PR
- [ ] Manual end-to-end import of a card with dimension-type template tags

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)