### PR TITLE
fix: add missing db_map.example.json (closes #59)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -110,6 +110,12 @@ cp db_map.example.json db_map.json
 **This is the most critical step for a successful import.** You must map every source database ID used by an
 exported card to a valid target database ID.
 
+Only `by_id` and `by_name` are read from `db_map.json`. Table, field, and collection IDs are remapped
+automatically by the importer using the Metabase metadata API.
+
+To find database IDs, open *Admin settings → Databases* in Metabase and read the ID from the URL, or call
+`GET /api/database` against the source and target instances and map source `id` → target `id`.
+
 ## Usage
 
 ### Exporting from Source

--- a/.github/README.md
+++ b/.github/README.md
@@ -110,8 +110,9 @@ cp db_map.example.json db_map.json
 **This is the most critical step for a successful import.** You must map every source database ID used by an
 exported card to a valid target database ID.
 
-Only `by_id` and `by_name` are read from `db_map.json`. Table, field, and collection IDs are remapped
-automatically by the importer using the Metabase metadata API.
+Only `by_id` and `by_name` are read from `db_map.json` — `by_id` is checked first, with `by_name` as a
+fallback. Table and field IDs are remapped automatically via the Metabase metadata API, and collection IDs
+are remapped as collections are created during import.
 
 To find database IDs, open *Admin settings → Databases* in Metabase and read the ID from the URL, or call
 `GET /api/database` against the source and target instances and map source `id` → target `id`.

--- a/README.md
+++ b/README.md
@@ -154,9 +154,11 @@ pip install --index-url https://test.pypi.org/simple/ \
     **This is the most critical step for a successful import.** You must map every source database ID used by an
     exported card to a valid target database ID.
 
-    Only `by_id` and `by_name` are read from `db_map.json`. Table, field, and collection IDs are remapped
-    automatically by the importer using the Metabase metadata API, so you do not need to (and cannot) configure
-    `table_map`/`field_map`/`collection_map` in this file.
+    Only `by_id` and `by_name` are read from `db_map.json`. The importer looks up `by_id` first (matching
+    against the source database ID as a string key) and falls back to `by_name` if no ID match is found.
+    Table and field IDs are remapped automatically by the importer using the Metabase metadata API, and
+    collection IDs are remapped as collections are created during the import — so you do not need to (and
+    cannot) configure `table_map`/`field_map`/`collection_map` in this file.
 
     **How to find database IDs:**
 

--- a/README.md
+++ b/README.md
@@ -148,8 +148,26 @@ pip install --index-url https://test.pypi.org/simple/ \
     # Edit db_map.json with your mappings
     ```
 
+    If you need richer starting points, see also `samples/db_map/db_map.single_db.json` and
+    `samples/db_map/db_map.multi_db.json`.
+
     **This is the most critical step for a successful import.** You must map every source database ID used by an
     exported card to a valid target database ID.
+
+    Only `by_id` and `by_name` are read from `db_map.json`. Table, field, and collection IDs are remapped
+    automatically by the importer using the Metabase metadata API, so you do not need to (and cannot) configure
+    `table_map`/`field_map`/`collection_map` in this file.
+
+    **How to find database IDs:**
+
+    - In the Metabase UI, open *Admin settings → Databases* and click a database — the URL contains its ID
+      (e.g., `/admin/databases/7` means database ID `7`).
+    - Or query the API: `GET /api/database` returns every database with its `id` and `name` on each instance.
+      Run it once against the source and once against the target, then map source `id` → target `id`.
+
+    If JOINs fail after import with errors about missing table or field IDs, it almost always means a source
+    database has no entry (by ID or by name) in `db_map.json` — the importer cannot derive table/field mappings
+    for an unmapped database.
 
 ## Usage
 
@@ -378,6 +396,7 @@ metabase-import --export-dir "./export" --db-map "./db_map.json" --apply-permiss
 
 The repository includes a `samples/` directory with ready-to-use templates:
 
+- `db_map.example.json` – minimal `db_map.json` template at the project root (copy-and-edit starter)
 - `samples/db_map/db_map.single_db.json` – minimal single-database mapping example
 - `samples/db_map/db_map.multi_db.json` – example mapping for multiple databases
 - `samples/flows/export_import_basic.sh` – basic end-to-end export/import flow using `.env`

--- a/db_map.example.json
+++ b/db_map.example.json
@@ -1,0 +1,10 @@
+{
+  "by_id": {
+    "1": 10,
+    "2": 20
+  },
+  "by_name": {
+    "Production DB": 10,
+    "Analytics DB": 20
+  }
+}

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -369,8 +369,19 @@ MB_METABASE_VERSION=v56
 2. Falls back to `by_name` for name-based mapping
 3. Fails if no mapping found
 
+Only `by_id` and `by_name` are read from this file — table, field, and collection IDs are remapped
+automatically using the Metabase metadata API, so JOINs work without any extra configuration as long as
+every source database referenced by an exported card has an entry here.
+
+**Finding database IDs:**
+
+- *UI:* open *Admin settings → Databases* in Metabase and click the database; the URL contains its numeric ID
+  (e.g., `/admin/databases/7`).
+- *API:* run `GET /api/database` against both instances and map source `id` → target `id`.
+
 For concrete examples, see the sample mapping files in the repository:
 
+- `db_map.example.json` – minimal copy-and-edit template at the project root
 - `samples/db_map/db_map.single_db.json` – minimal single-database mapping
 - `samples/db_map/db_map.multi_db.json` – multi-database mapping, useful for complex environments
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -369,9 +369,10 @@ MB_METABASE_VERSION=v56
 2. Falls back to `by_name` for name-based mapping
 3. Fails if no mapping found
 
-Only `by_id` and `by_name` are read from this file — table, field, and collection IDs are remapped
-automatically using the Metabase metadata API, so JOINs work without any extra configuration as long as
-every source database referenced by an exported card has an entry here.
+Only `by_id` and `by_name` are read from this file (see the precedence rules above). Table and field IDs
+are remapped automatically using the Metabase metadata API, and collection IDs are remapped as collections
+are created during import — so JOINs work without any extra configuration as long as every source database
+referenced by an exported card has an entry here.
 
 **Finding database IDs:**
 


### PR DESCRIPTION
## Summary

- Add `db_map.example.json` at the project root so `cp db_map.example.json db_map.json` (documented in `README.md`, `.github/README.md`, and `docs/QUICK_START.md`) actually works.
- Document **how to find database IDs** — read the ID from the *Admin → Databases* URL or call `GET /api/database` against both instances and map source `id` → target `id`.
- Clarify that only `by_id` and `by_name` are read from `db_map.json`. Table, field, and collection IDs are remapped automatically by the importer via the Metabase metadata API, so users do not need to (and cannot) configure `table_map`/`field_map`/`collection_map` in this file.

The issue's proposed JSON included those extra keys, but the loader in `lib/services/import_service.py` only reads `by_id`/`by_name` (`DatabaseMap` dataclass in `lib/models_core.py`), and the table/field maps are built at runtime by `IDMapper.build_table_and_field_mappings()`. Adding unsupported keys to the example would have misled users into thinking they could pin JOIN mappings — instead, the new docs explain why JOINs already work as long as every source DB has an entry.

Closes #59.

## Test plan

- [ ] `cp db_map.example.json db_map.json` succeeds from a fresh clone
- [ ] `python -m json.tool db_map.example.json` exits 0 (valid JSON)
- [ ] README, `.github/README.md`, and `docs/QUICK_START.md` render correctly and reference the new file