### PR TITLE
add --exclude-databases flag to export and syn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`--exclude-databases` export flag**: Skip every card whose database is in a comma-separated
+  list of database IDs (e.g. `--exclude-databases "4,24,39"`). Useful for legacy instances with
+  questions pointing to databases that no longer exist (such as the removed Google Analytics
+  driver), which previously forced manual edits to `manifest.json` to get the import past
+  database-mapping validation. Skipped cards are logged and counted in the export summary;
+  dashboards still export in full, and dashcards referencing excluded cards are dropped
+  gracefully on import. Also available on `metabase-sync`.
+
 ### Fixed
 
 - **Card parameter value source remapping**: Card filters that source dropdown values from

--- a/README.md
+++ b/README.md
@@ -214,7 +214,19 @@ metabase-export \
 - `--include-archived` - Include archived items
 - `--include-permissions` - Include permissions (groups and access control) in export
 - `--root-collections` - Comma-separated collection IDs to export (optional)
+- `--exclude-databases` - Comma-separated database IDs whose cards are skipped during export (optional).
+  Useful when the source instance still has questions pointing to removed databases (e.g. the legacy
+  Google Analytics driver) that would otherwise block the import.
 - `--log-level` - Logging level: DEBUG, INFO, WARNING, ERROR
+
+**Example excluding dead databases:**
+
+```bash
+metabase-export \
+    --export-dir "./metabase_export" \
+    --include-dashboards \
+    --exclude-databases "4,24,39"
+```
 
 ### 2. Importing to a Target Metabase
 
@@ -330,6 +342,7 @@ metabase-sync \
 - `--include-archived` - Include archived items
 - `--include-permissions` - Include permissions (groups and access control)
 - `--root-collections` - Comma-separated list of root collection IDs to export
+- `--exclude-databases` - Comma-separated list of database IDs whose cards are skipped during export
 
 *Import Options:*
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -145,6 +145,7 @@ class ExportConfig(BaseModel):
     include_archived: bool = False
     include_permissions: bool = False
     root_collection_ids: list[int] | None = None
+    exclude_database_ids: list[int] | None = None
     log_level: str = "INFO"
 
     @field_validator("source_url")
@@ -186,6 +187,25 @@ class ExportConfig(BaseModel):
                 raise ConfigValidationError(
                     f"Collection IDs must be positive integers, got {collection_id} at index {i}",
                     field="root_collection_ids",
+                )
+
+        return v
+
+    @field_validator("exclude_database_ids")
+    @classmethod
+    def validate_database_ids(cls, v: list[int] | None) -> list[int] | None:
+        """Validate that database IDs are positive integers."""
+        if v is None:
+            return v
+
+        if not v:
+            return None  # Empty list treated as None (exclude nothing)
+
+        for i, database_id in enumerate(v):
+            if database_id <= 0:
+                raise ConfigValidationError(
+                    f"Database IDs must be positive integers, got {database_id} at index {i}",
+                    field="exclude_database_ids",
                 )
 
         return v
@@ -335,6 +355,10 @@ def get_export_args() -> ExportConfig:
         help="Comma-separated list of root collection IDs to export (empty=all)",
     )
     parser.add_argument(
+        "--exclude-databases",
+        help="Comma-separated list of database IDs whose cards are skipped during export",
+    )
+    parser.add_argument(
         "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -366,6 +390,18 @@ def get_export_args() -> ExportConfig:
                 f"--root-collections must be comma-separated integers, got '{args.root_collections}'"
             )
 
+    # Parse excluded database IDs
+    exclude_database_ids: list[int] | None = None
+    if args.exclude_databases:
+        try:
+            exclude_database_ids = [
+                int(db_id.strip()) for db_id in args.exclude_databases.split(",")
+            ]
+        except ValueError:
+            parser.error(
+                f"--exclude-databases must be comma-separated integers, got '{args.exclude_databases}'"
+            )
+
     # Create config object with validation
     try:
         return ExportConfig(
@@ -380,6 +416,7 @@ def get_export_args() -> ExportConfig:
             include_archived=args.include_archived,
             include_permissions=args.include_permissions,
             root_collection_ids=root_collection_ids,
+            exclude_database_ids=exclude_database_ids,
             log_level=args.log_level,
         )
     except ConfigValidationError as e:
@@ -527,6 +564,7 @@ class SyncConfig(BaseModel):
     include_archived: bool = False
     include_permissions: bool = False
     root_collection_ids: list[int] | None = None
+    exclude_database_ids: list[int] | None = None
 
     # Import options
     conflict_strategy: Literal["skip", "overwrite", "rename"] = "skip"
@@ -600,6 +638,25 @@ class SyncConfig(BaseModel):
 
         return v
 
+    @field_validator("exclude_database_ids")
+    @classmethod
+    def validate_database_ids(cls, v: list[int] | None) -> list[int] | None:
+        """Validate that database IDs are positive integers."""
+        if v is None:
+            return v
+
+        if not v:
+            return None  # Empty list treated as None (exclude nothing)
+
+        for i, database_id in enumerate(v):
+            if database_id <= 0:
+                raise ConfigValidationError(
+                    f"Database IDs must be positive integers, got {database_id} at index {i}",
+                    field="exclude_database_ids",
+                )
+
+        return v
+
     @model_validator(mode="after")
     def validate_authentication(self) -> "SyncConfig":
         """Validate that at least one authentication method is provided for both source and target."""
@@ -643,6 +700,7 @@ class SyncConfig(BaseModel):
             include_archived=self.include_archived,
             include_permissions=self.include_permissions,
             root_collection_ids=self.root_collection_ids,
+            exclude_database_ids=self.exclude_database_ids,
             log_level=self.log_level,
         )
 
@@ -753,6 +811,10 @@ def get_sync_args() -> SyncConfig:
         "--root-collections",
         help="Comma-separated list of root collection IDs to export (empty=all)",
     )
+    export_group.add_argument(
+        "--exclude-databases",
+        help="Comma-separated list of database IDs whose cards are skipped during export",
+    )
 
     # Import options
     import_group = parser.add_argument_group("Import Options")
@@ -800,6 +862,18 @@ def get_sync_args() -> SyncConfig:
                 f"--root-collections must be comma-separated integers, got '{args.root_collections}'"
             )
 
+    # Parse excluded database IDs
+    exclude_database_ids: list[int] | None = None
+    if args.exclude_databases:
+        try:
+            exclude_database_ids = [
+                int(db_id.strip()) for db_id in args.exclude_databases.split(",")
+            ]
+        except ValueError:
+            parser.error(
+                f"--exclude-databases must be comma-separated integers, got '{args.exclude_databases}'"
+            )
+
     # Create config object with validation
     try:
         return SyncConfig(
@@ -820,6 +894,7 @@ def get_sync_args() -> SyncConfig:
             include_archived=args.include_archived,
             include_permissions=args.include_permissions,
             root_collection_ids=root_collection_ids,
+            exclude_database_ids=exclude_database_ids,
             conflict_strategy=args.conflict,
             dry_run=args.dry_run,
             apply_permissions=args.apply_permissions,

--- a/lib/services/export_service.py
+++ b/lib/services/export_service.py
@@ -50,6 +50,7 @@ class ExportService:
         self._collection_path_map: dict[int, str] = {}
         self._processed_collections: set[int] = set()
         self._exported_cards: set[int] = set()  # Track exported cards to prevent duplicates
+        self._excluded_cards: set[int] = set()  # Cards skipped due to excluded databases
         self._dependency_chain: list[int] = (
             []
         )  # Track current dependency chain for circular detection
@@ -83,6 +84,11 @@ class ExportService:
         """Main entry point to start the export process."""
         logger.info(f"Starting Metabase export from {self.config.source_url}")
         logger.info(f"Export directory: {self.export_dir.resolve()}")
+
+        if self.config.exclude_database_ids:
+            logger.info(
+                f"Excluding cards from databases: {sorted(set(self.config.exclude_database_ids))}"
+            )
 
         self.export_dir.mkdir(parents=True, exist_ok=True)
 
@@ -130,6 +136,8 @@ class ExportService:
             logger.info("Export Summary:")
             logger.info(f"  Collections: {len(self.manifest.collections)}")
             logger.info(f"  Cards: {len(self.manifest.cards)}")
+            if self.config.exclude_database_ids:
+                logger.info(f"  Cards skipped (excluded databases): {len(self._excluded_cards)}")
             logger.info(f"  Dashboards: {len(self.manifest.dashboards)}")
             logger.info(f"  Databases: {len(self.manifest.databases)}")
             if self.config.include_permissions:
@@ -337,6 +345,44 @@ class ExportService:
                 )
 
     @staticmethod
+    def _resolve_card_database_id(card_data: dict) -> int | None:
+        """Resolves the database ID a card belongs to.
+
+        Args:
+            card_data: The card data dictionary.
+
+        Returns:
+            The database ID, or None if the card has no database reference.
+        """
+        return card_data.get("database_id") or (card_data.get("dataset_query") or {}).get(
+            "database"
+        )
+
+    def _is_card_excluded(self, card_id: int, card_data: dict) -> bool:
+        """Checks whether a card belongs to an excluded database.
+
+        Args:
+            card_id: The ID of the card being checked.
+            card_data: The card data dictionary.
+
+        Returns:
+            True if the card's database is in the configured exclusion list.
+        """
+        if not self.config.exclude_database_ids:
+            return False
+
+        db_id = self._resolve_card_database_id(card_data)
+        if db_id in self.config.exclude_database_ids:
+            self._excluded_cards.add(card_id)
+            logger.info(
+                f"Skipping card '{card_data.get('name', 'Unknown')}' (ID: {card_id}): "
+                f"database {db_id} is excluded"
+            )
+            return True
+
+        return False
+
+    @staticmethod
     def _extract_card_dependencies(card_data: dict) -> set[int]:
         """Extracts card IDs that this card depends on.
 
@@ -420,8 +466,8 @@ class ExportService:
             is_model_hint: Hint from collection listing that this is a model (model='dataset').
             dependency_chain: List of card IDs in the current dependency chain (for circular detection).
         """
-        # Skip if already exported
-        if card_id in self._exported_cards:
+        # Skip if already exported or already excluded
+        if card_id in self._exported_cards or card_id in self._excluded_cards:
             return
 
         # Initialize dependency chain if not provided
@@ -439,6 +485,10 @@ class ExportService:
 
         try:
             card_data = self.client.get_card(card_id)
+
+            # Skip cards from excluded databases before traversing their dependencies
+            if self._is_card_excluded(card_id, card_data):
+                return
 
             # Extract dependencies
             dependencies = self._extract_card_dependencies(card_data)
@@ -520,13 +570,16 @@ class ExportService:
             if card_data is None:
                 card_data = self.client.get_card(card_id)
 
+            if self._is_card_excluded(card_id, card_data):
+                return
+
             if not card_data.get("dataset_query"):
                 logger.warning(
                     f"Card ID {card_id} ('{card_data['name']}') has no dataset_query. Skipping."
                 )
                 return
 
-            db_id = card_data.get("database_id") or card_data["dataset_query"].get("database")
+            db_id = self._resolve_card_database_id(card_data)
             if db_id is None:
                 logger.warning(
                     f"Card ID {card_id} ('{card_data['name']}') has no database ID. Skipping."
@@ -624,7 +677,7 @@ class ExportService:
 
             # Export all card dependencies
             for card_id in card_ids:
-                if card_id not in self._exported_cards:
+                if card_id not in self._exported_cards and card_id not in self._excluded_cards:
                     logger.info(
                         f"     Exporting card {card_id} (required by dashboard {dashboard_id})"
                     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,6 +60,7 @@ class TestExportConfig:
         assert config.include_dashboards is False
         assert config.include_archived is False
         assert config.root_collection_ids is None
+        assert config.exclude_database_ids is None
         assert config.log_level == "INFO"
 
     def test_export_config_with_session_token(self):
@@ -242,6 +243,52 @@ class TestExportConfigValidation:
         )
 
         assert config.root_collection_ids is None
+
+    def test_exclude_database_ids_accepted(self):
+        """Test that valid excluded database IDs are accepted."""
+        config = ExportConfig(
+            source_url="https://example.com",
+            export_dir="./export",
+            source_session_token="token123",
+            exclude_database_ids=[4, 24, 39],
+        )
+
+        assert config.exclude_database_ids == [4, 24, 39]
+
+    def test_negative_exclude_database_ids(self):
+        """Test that negative excluded database IDs are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            ExportConfig(
+                source_url="https://example.com",
+                export_dir="./export",
+                source_session_token="token123",
+                exclude_database_ids=[4, -24],
+            )
+
+        assert "positive" in str(exc_info.value).lower()
+
+    def test_zero_exclude_database_id(self):
+        """Test that zero excluded database IDs are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            ExportConfig(
+                source_url="https://example.com",
+                export_dir="./export",
+                source_session_token="token123",
+                exclude_database_ids=[0],
+            )
+
+        assert "positive" in str(exc_info.value).lower()
+
+    def test_empty_exclude_database_ids_becomes_none(self):
+        """Test that empty excluded database IDs list becomes None."""
+        config = ExportConfig(
+            source_url="https://example.com",
+            export_dir="./export",
+            source_session_token="token123",
+            exclude_database_ids=[],
+        )
+
+        assert config.exclude_database_ids is None
 
     def test_extra_fields_rejected(self):
         """Test that extra fields are rejected."""
@@ -542,6 +589,54 @@ class TestGetExportArgs:
         assert config.source_url == "https://cli.example.com"
         # CLI session token should be used
         assert config.source_session_token == "session-token"
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch(
+        "sys.argv",
+        [
+            "export_metabase.py",
+            "--source-url",
+            "https://cli.example.com",
+            "--source-session",
+            "session-token",
+            "--export-dir",
+            "./cli_export",
+            "--exclude-databases",
+            "4,24,39",
+        ],
+    )
+    def test_get_export_args_exclude_databases(self):
+        """Test parsing --exclude-databases into a list of integers."""
+        from lib.config import get_export_args
+
+        config = get_export_args()
+
+        assert config.exclude_database_ids == [4, 24, 39]
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch(
+        "sys.argv",
+        [
+            "export_metabase.py",
+            "--source-url",
+            "https://cli.example.com",
+            "--source-session",
+            "session-token",
+            "--export-dir",
+            "./cli_export",
+            "--exclude-databases",
+            "a,b",
+        ],
+    )
+    def test_get_export_args_exclude_databases_invalid(self, capsys):
+        """Test that non-integer --exclude-databases values exit with an error."""
+        from lib.config import get_export_args
+
+        with pytest.raises(SystemExit):
+            get_export_args()
+
+        captured = capsys.readouterr()
+        assert "--exclude-databases must be comma-separated integers" in captured.err
 
 
 class TestGetImportArgs:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -374,6 +374,138 @@ class TestModelExport:
             assert exported_card.dataset is False
 
 
+class TestExcludeDatabases:
+    """Test suite for skipping cards from excluded databases."""
+
+    @staticmethod
+    def _make_config(tmp_path, exclude_database_ids):
+        return ExportConfig(
+            source_url="https://example.com",
+            export_dir=str(tmp_path / "export"),
+            source_session_token="token",
+            exclude_database_ids=exclude_database_ids,
+        )
+
+    @staticmethod
+    def _make_card(card_id, database_id):
+        return {
+            "id": card_id,
+            "name": f"Card {card_id}",
+            "database_id": database_id,
+            "dataset_query": {"database": database_id, "type": "query", "query": {}},
+        }
+
+    def test_excluded_card_not_exported(self, tmp_path):
+        """Test that a card from an excluded database is skipped entirely."""
+        config = self._make_config(tmp_path, exclude_database_ids=[4])
+
+        with patch("lib.services.export_service.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_card.return_value = self._make_card(100, database_id=4)
+            mock_client_class.return_value = mock_client
+
+            exporter = MetabaseExporter(config)
+            exporter._export_card_with_dependencies(100, "test-collection")
+
+            assert exporter.manifest.cards == []
+            assert 100 in exporter._excluded_cards
+            # No card file must be written
+            assert not list(Path(config.export_dir).rglob("card_*.json"))
+
+    def test_non_excluded_card_still_exported(self, tmp_path):
+        """Test that cards from other databases are exported normally."""
+        config = self._make_config(tmp_path, exclude_database_ids=[4])
+
+        with patch("lib.services.export_service.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_card.return_value = self._make_card(100, database_id=1)
+            mock_client_class.return_value = mock_client
+
+            exporter = MetabaseExporter(config)
+            exporter._export_card_with_dependencies(100, "test-collection")
+
+            assert len(exporter.manifest.cards) == 1
+            assert exporter.manifest.cards[0].id == 100
+            assert exporter._excluded_cards == set()
+
+    def test_no_exclusion_when_flag_absent(self, tmp_path):
+        """Test that no cards are skipped when exclude_database_ids is None."""
+        config = self._make_config(tmp_path, exclude_database_ids=None)
+
+        with patch("lib.services.export_service.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_card.return_value = self._make_card(100, database_id=4)
+            mock_client_class.return_value = mock_client
+
+            exporter = MetabaseExporter(config)
+            exporter._export_card_with_dependencies(100, "test-collection")
+
+            assert len(exporter.manifest.cards) == 1
+            assert exporter.manifest.cards[0].database_id == 4
+
+    def test_excluded_card_dependencies_not_fetched(self, tmp_path):
+        """Test that dependencies of an excluded card are not traversed."""
+        config = self._make_config(tmp_path, exclude_database_ids=[4])
+
+        excluded_card = self._make_card(100, database_id=4)
+        excluded_card["dataset_query"]["query"] = {"source-table": "card__55"}
+
+        with patch("lib.services.export_service.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_card.return_value = excluded_card
+            mock_client_class.return_value = mock_client
+
+            exporter = MetabaseExporter(config)
+            exporter._export_card_with_dependencies(100, "test-collection")
+
+            # Only the excluded card itself is fetched; its dependency (55) is not
+            mock_client.get_card.assert_called_once_with(100)
+            assert exporter.manifest.cards == []
+
+    def test_exclusion_resolves_database_from_dataset_query(self, tmp_path):
+        """Test that the database ID falls back to dataset_query when database_id is absent."""
+        config = self._make_config(tmp_path, exclude_database_ids=[4])
+
+        card = self._make_card(100, database_id=4)
+        del card["database_id"]
+
+        with patch("lib.services.export_service.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_card.return_value = card
+            mock_client_class.return_value = mock_client
+
+            exporter = MetabaseExporter(config)
+            exporter._export_card_with_dependencies(100, "test-collection")
+
+            assert exporter.manifest.cards == []
+            assert 100 in exporter._excluded_cards
+
+    def test_dashboard_keeps_excluded_card_reference(self, tmp_path):
+        """Test that dashboards export fully, listing excluded cards without exporting them."""
+        config = self._make_config(tmp_path, exclude_database_ids=[4])
+
+        with patch("lib.services.export_service.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_dashboard.return_value = {
+                "id": 1,
+                "name": "Test Dashboard",
+                "collection_id": 10,
+                "dashcards": [{"id": 1, "card_id": 100}],
+                "parameters": [],
+            }
+            mock_client.get_card.return_value = self._make_card(100, database_id=4)
+            mock_client_class.return_value = mock_client
+
+            exporter = MetabaseExporter(config)
+            exporter._export_dashboard(1, "test-collection")
+
+            # Dashboard is exported in full; the excluded card is not
+            assert len(exporter.manifest.dashboards) == 1
+            assert exporter.manifest.dashboards[0].ordered_cards == [100]
+            assert exporter.manifest.cards == []
+            assert 100 in exporter._excluded_cards
+
+
 class TestExportDashboard:
     """Test suite for _export_dashboard method."""
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -272,6 +272,21 @@ class TestSyncConfigValidation:
 
         assert "positive" in str(exc_info.value).lower()
 
+    def test_negative_exclude_database_ids(self):
+        """Test that negative excluded database IDs are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            SyncConfig(
+                source_url="https://source.example.com",
+                source_session_token="token",
+                target_url="https://target.example.com",
+                target_session_token="token",
+                export_dir="./export",
+                db_map_path="./db_map.json",
+                exclude_database_ids=[4, -24],
+            )
+
+        assert "positive" in str(exc_info.value).lower()
+
 
 class TestSyncConfigConversion:
     """Test SyncConfig conversion to ExportConfig and ImportConfig."""
@@ -290,6 +305,7 @@ class TestSyncConfigConversion:
             include_archived=True,
             include_permissions=True,
             root_collection_ids=[1, 2, 3],
+            exclude_database_ids=[4, 24],
             log_level="DEBUG",
         )
 
@@ -303,6 +319,7 @@ class TestSyncConfigConversion:
         assert export_config.include_archived is True
         assert export_config.include_permissions is True
         assert export_config.root_collection_ids == [1, 2, 3]
+        assert export_config.exclude_database_ids == [4, 24]
         assert export_config.log_level == "DEBUG"
 
     def test_to_import_config(self):
@@ -419,6 +436,8 @@ class TestGetSyncArgs:
             "overwrite",
             "--root-collections",
             "24,25",
+            "--exclude-databases",
+            "4,39",
             "--log-level",
             "DEBUG",
         ],
@@ -442,6 +461,7 @@ class TestGetSyncArgs:
         assert config.apply_permissions is True
         assert config.conflict_strategy == "overwrite"
         assert config.root_collection_ids == [24, 25]
+        assert config.exclude_database_ids == [4, 39]
         assert config.log_level == "DEBUG"
 
     @patch.dict(


### PR DESCRIPTION
# Pull Request                                                                                                                                                                                                                         
                                                                                                                                                                                                                                         
  ## Description                                                                                                                                                                                                                         
                                                                                                                                                                                                                                         
  Adds an `--exclude-databases` flag to `metabase-export` (and `metabase-sync`) that skips every                                                                                                                                         
  card whose database ID is in a comma-separated list. Legacy instances often contain questions                                                                                                                                          
  bound to databases that no longer exist (e.g. the removed Google Analytics driver); those                                                                                                                                              
  databases can never be mapped in `db_map.json`, so the import failed hard at                                                                                                                                                           
  `_validate_database_mappings()` and the only workaround was hand-editing `manifest.json`.                                                                                                                                              
  This keeps the archive clean at export time instead.                                                                                                                                                                                   
                                                                                                                                                                                                                                         
  Skipped cards are absent from `manifest.cards`, their files are not written, each skip is                                                                                                                                              
  logged at INFO, and the export summary reports `Cards skipped (excluded databases): N`.                                                                                                                                                
  The check runs before dependency traversal, so dependencies of excluded cards are never                                                                                                                                                
  fetched. Dashboards still export in full — dashcards referencing excluded cards are already                                                                                                                                            
  dropped gracefully at import time (`lib/handlers/dashboard.py`, "Skipping dashcard with                                                                                                                                                
  unmapped card_id"), so no import-side changes are needed. Fully independent from                                                                                                                                                       
  `--root-collections`; both flags can be combined.                                                                                                                                                                                      
                                                                                                                                                                                                                                         
  ```bash                                                                                                                                                                                                                                
  metabase-export --export-dir ./export --include-dashboards --exclude-databases "4,24,39"                                                                                                                                               
  ``` 

## Type of Change                                                                                                                                                                                                                      
                                                                                                                                                                                                                                         
  - [ ] Bug fix (non-breaking change which fixes an issue)                                                                                                                                                                               
  - [x] New feature (non-breaking change which adds functionality)                                                                                                                                                                       
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)                                                                                                                                 
  - [ ] Documentation update                                                                                                                                                                                                             
  - [ ] Code refactoring                                                                                                                                                                                                                 
  - [ ] Performance improvement                                                                                                                                                                                                          
  - [ ] Test coverage improvement                                                                                                                                                                                                        
  - [ ] CI/CD improvement                                                                                                                                                                                                                
                                                                                                                                                                                                                                         
  ## Related Issues                                                                                                                                                                                                                      
                                                                                                                                                                                                                                         
  Fixes #67 

## Changes Made                                                                                                                                                                                                                        
                                                                                                                                                                                                                                         
  - `lib/config.py`: new `exclude_database_ids: list[int] | None` field on `ExportConfig` and                                                                                                                                            
    `SyncConfig` with a positive-integer Pydantic validator (empty list → `None`), the                                                                                                                                                   
    `--exclude-databases` argparse flag in `get_export_args()` / `get_sync_args()` mirroring the                                                                                                                                         
    `--root-collections` parsing and error message, and pass-through in `to_export_config()`.                                                                                                                                            
  - `lib/services/export_service.py`: exclusion check in `_export_card_with_dependencies()`                                                                                                                                              
    right after fetching the card (before dependency recursion), via new helpers                                                                                                                                                         
    `_resolve_card_database_id()` (same `database_id` → `dataset_query.database` resolution the                                                                                                                                          
    exporter already used) and `_is_card_excluded()`; excluded-card tracking to avoid re-fetching                                                                                                                                        
    on repeated dashboard references; INFO log per skip and a summary count.                                                                                                                                                             
  - Tests: exclusion behavior in `tests/test_export.py` (manifest, files on disk, dependency                                                                                                                                             
    traversal, dashboard references, `dataset_query` fallback), config validation and CLI parsing                                                                                                                                        
    (including the non-integer error path) in `tests/test_config.py` and `tests/test_sync.py`.                                                                                                                                           
  - Docs: README export/sync option lists plus a usage example, and a CHANGELOG entry under                                                                                                                                              
    Unreleased.                                                                                                                                                                                                                          
                                                                                                                                                                                                                                         
  ## Testing                                                                                                                                                                                                                             
                                                                                                                                                                                                                                         
  ### Test Configuration                                                                                                                                                                                                                 
                                                                                                                                                                                                                                         
  - Python version: 3.10.13                                                                                                                                                                                                              
  - Operating System: macOS (Darwin 25.5)                                                                                                                                                                                                
  - Metabase version (if applicable): N/A (unit tests with mocked API client)

### Test Results                                                                                                                                                                                                                       
                                                                                                                                                                                                                                         
  - [x] All existing tests pass                                                                                                                                                                                                          
  - [x] New tests added and passing                                                                                                                                                                                                      
  - [ ] Manual testing completed                                                                                                                                                                                                         
                                                                                                                                                                                                                                         
  763 passed, 3 skipped; coverage 86.81% (threshold 85%). Manual verification was limited to                                                                                                                                             
  CLI smoke tests (`--help` output and argument parsing on both entry points); no run against a                                                                                                                                          
  live Metabase instance.                                                                                                                                                                                                                
                                                                                                                                                                                                                                         
  ### Test Commands Run                                                                                                                                                                                                                  
                                                                                                                                                                                                                                         
  ```bash                                                                                                                                                                                                                                
  pytest tests/ -m "not integration"   # 763 passed, 3 skipped, coverage 86.81%                                                                                                                                                          
  black --check lib/ tests/ *.py                                                                                                                                                                                                         
  ruff check lib/ tests/ *.py                                                                                                                                                                                                            
  mypy lib/ --ignore-missing-imports                                                                                                                                                                                                     
  ```                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                         
  ## Screenshots (if applicable)                                                                                                                                                                                                         
                                                                                                                                                                                                                                         
  N/A

## Checklist                                                                                                                                                                                                                           
                                                                                                                                                                                                                                         
  - [x] My code follows the project's style guidelines                                                                                                                                                                                   
  - [x] I have performed a self-review of my own code                                                                                                                                                                                    
  - [x] I have commented my code, particularly in hard-to-understand areas                                                                                                                                                               
  - [x] I have made corresponding changes to the documentation                                                                                                                                                                           
  - [x] My changes generate no new warnings                                                                                                                                                                                              
  - [x] I have added tests that prove my fix is effective or that my feature works                                                                                                                                                       
  - [x] New and existing unit tests pass locally with my changes                                                                                                                                                                         
  - [x] Any dependent changes have been merged and published                                                                                                                                                                             
  - [x] I have updated the CHANGELOG.md file                                                                                                                                                                                             
  - [x] I have checked my code with black, ruff, and mypy                                                                                                                                                                                
                                                                                                                                                                                                                                         
  ## Breaking Changes                                                                                                                                                                                                                    
                                                                                                                                                                                                                                         
  None / N/A                                                                                                                                                                                                                             
                                                                                                                                                                                                                                         
  ## Migration Guide                                                                                                                                                                                                                     
                                                                                                                                                                                                                                         
  N/A 

## Additional Notes                                                                                                                                                                                                                    
                                                                                                                                                                                                                                         
  - If a *kept* card depends on a card living in an excluded database, that dependency is                                                                                                                                                
    omitted from the package. The importer already tolerates missing dependencies with a                                                                                                                                                 
    warning — the same path taken today when a dependency fetch fails.                                                                                                                                                                   
  - `isort --check-only` reports 6 files on current `main` (imports untouched by this PR);                                                                                                                                               
    left as-is to keep the diff focused. Happy to fix in a separate `style:` PR.                                                                                                                                                         
                                                                                                                                                                                                                                         
  ## Code Quality                                                                                                                                                                                                                        
                                                                                                                                                                                                                                         
  ```bash                                                                                                                                                                                                                                
  # Run these commands before submitting:                                                                                                                                                                                                
  black lib/ tests/ *.py                                                                                                                                                                                                                 
  ruff check lib/ tests/ *.py                                                                                                                                                                                                            
  mypy lib/                                                                                                                                                                                                                              
  pytest --cov=lib                                                                                                                                                                                                                       
  ```                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                         
  ---                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                         
  **By submitting this pull request, I confirm that my contribution is made under the terms of the MIT License.**