### PR TITLE
test: raise unit test coverage to 97.76% and enforce a 95% threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`--exclude-databases` export flag**: Skip every card whose database is in a comma-separated
+  list of database IDs (e.g. `--exclude-databases "4,24,39"`). Useful for legacy instances with
+  questions pointing to databases that no longer exist (such as the removed Google Analytics
+  driver), which previously forced manual edits to `manifest.json` to get the import past
+  database-mapping validation. Skipped cards are logged and counted in the export summary;
+  dashboards still export in full, and dashcards referencing excluded cards are dropped
+  gracefully on import. Also available on `metabase-sync`.
+
 ### Fixed
 
 - **Card parameter value source remapping**: Card filters that source dropdown values from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dashboards still export in full, and dashcards referencing excluded cards are dropped
   gracefully on import. Also available on `metabase-sync`.
 
+### Changed
+
+- **Unit test coverage raised to 97.76%** (from 86.81%) and the enforced coverage threshold
+  raised from 85% to 95%. New suites cover the previously untested branches of
+  `lib/remapping/query_remapper.py` (64.79% → 99.86%), `lib/services/export_service.py`
+  (74.53% → 99.59%), `lib/remapping/id_mapper.py` and the `parser.error()` paths in
+  `lib/config.py`: `tests/test_query_remapper.py`, `tests/test_export_service_internals.py`,
+  `tests/test_id_mapper.py`, `tests/test_config_cli_errors.py` and
+  `tests/test_misc_coverage_gaps.py`.
+
 ### Fixed
 
 - **Card parameter value source remapping**: Card filters that source dropdown values from

--- a/README.md
+++ b/README.md
@@ -214,7 +214,19 @@ metabase-export \
 - `--include-archived` - Include archived items
 - `--include-permissions` - Include permissions (groups and access control) in export
 - `--root-collections` - Comma-separated collection IDs to export (optional)
+- `--exclude-databases` - Comma-separated database IDs whose cards are skipped during export (optional).
+  Useful when the source instance still has questions pointing to removed databases (e.g. the legacy
+  Google Analytics driver) that would otherwise block the import.
 - `--log-level` - Logging level: DEBUG, INFO, WARNING, ERROR
+
+**Example excluding dead databases:**
+
+```bash
+metabase-export \
+    --export-dir "./metabase_export" \
+    --include-dashboards \
+    --exclude-databases "4,24,39"
+```
 
 ### 2. Importing to a Target Metabase
 
@@ -330,6 +342,7 @@ metabase-sync \
 - `--include-archived` - Include archived items
 - `--include-permissions` - Include permissions (groups and access control)
 - `--root-collections` - Comma-separated list of root collection IDs to export
+- `--exclude-databases` - Comma-separated list of database IDs whose cards are skipped during export
 
 *Import Options:*
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -145,6 +145,7 @@ class ExportConfig(BaseModel):
     include_archived: bool = False
     include_permissions: bool = False
     root_collection_ids: list[int] | None = None
+    exclude_database_ids: list[int] | None = None
     log_level: str = "INFO"
 
     @field_validator("source_url")
@@ -186,6 +187,25 @@ class ExportConfig(BaseModel):
                 raise ConfigValidationError(
                     f"Collection IDs must be positive integers, got {collection_id} at index {i}",
                     field="root_collection_ids",
+                )
+
+        return v
+
+    @field_validator("exclude_database_ids")
+    @classmethod
+    def validate_database_ids(cls, v: list[int] | None) -> list[int] | None:
+        """Validate that database IDs are positive integers."""
+        if v is None:
+            return v
+
+        if not v:
+            return None  # Empty list treated as None (exclude nothing)
+
+        for i, database_id in enumerate(v):
+            if database_id <= 0:
+                raise ConfigValidationError(
+                    f"Database IDs must be positive integers, got {database_id} at index {i}",
+                    field="exclude_database_ids",
                 )
 
         return v
@@ -335,6 +355,10 @@ def get_export_args() -> ExportConfig:
         help="Comma-separated list of root collection IDs to export (empty=all)",
     )
     parser.add_argument(
+        "--exclude-databases",
+        help="Comma-separated list of database IDs whose cards are skipped during export",
+    )
+    parser.add_argument(
         "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -366,6 +390,18 @@ def get_export_args() -> ExportConfig:
                 f"--root-collections must be comma-separated integers, got '{args.root_collections}'"
             )
 
+    # Parse excluded database IDs
+    exclude_database_ids: list[int] | None = None
+    if args.exclude_databases:
+        try:
+            exclude_database_ids = [
+                int(db_id.strip()) for db_id in args.exclude_databases.split(",")
+            ]
+        except ValueError:
+            parser.error(
+                f"--exclude-databases must be comma-separated integers, got '{args.exclude_databases}'"
+            )
+
     # Create config object with validation
     try:
         return ExportConfig(
@@ -380,6 +416,7 @@ def get_export_args() -> ExportConfig:
             include_archived=args.include_archived,
             include_permissions=args.include_permissions,
             root_collection_ids=root_collection_ids,
+            exclude_database_ids=exclude_database_ids,
             log_level=args.log_level,
         )
     except ConfigValidationError as e:
@@ -527,6 +564,7 @@ class SyncConfig(BaseModel):
     include_archived: bool = False
     include_permissions: bool = False
     root_collection_ids: list[int] | None = None
+    exclude_database_ids: list[int] | None = None
 
     # Import options
     conflict_strategy: Literal["skip", "overwrite", "rename"] = "skip"
@@ -600,6 +638,25 @@ class SyncConfig(BaseModel):
 
         return v
 
+    @field_validator("exclude_database_ids")
+    @classmethod
+    def validate_database_ids(cls, v: list[int] | None) -> list[int] | None:
+        """Validate that database IDs are positive integers."""
+        if v is None:
+            return v
+
+        if not v:
+            return None  # Empty list treated as None (exclude nothing)
+
+        for i, database_id in enumerate(v):
+            if database_id <= 0:
+                raise ConfigValidationError(
+                    f"Database IDs must be positive integers, got {database_id} at index {i}",
+                    field="exclude_database_ids",
+                )
+
+        return v
+
     @model_validator(mode="after")
     def validate_authentication(self) -> "SyncConfig":
         """Validate that at least one authentication method is provided for both source and target."""
@@ -643,6 +700,7 @@ class SyncConfig(BaseModel):
             include_archived=self.include_archived,
             include_permissions=self.include_permissions,
             root_collection_ids=self.root_collection_ids,
+            exclude_database_ids=self.exclude_database_ids,
             log_level=self.log_level,
         )
 
@@ -753,6 +811,10 @@ def get_sync_args() -> SyncConfig:
         "--root-collections",
         help="Comma-separated list of root collection IDs to export (empty=all)",
     )
+    export_group.add_argument(
+        "--exclude-databases",
+        help="Comma-separated list of database IDs whose cards are skipped during export",
+    )
 
     # Import options
     import_group = parser.add_argument_group("Import Options")
@@ -800,6 +862,18 @@ def get_sync_args() -> SyncConfig:
                 f"--root-collections must be comma-separated integers, got '{args.root_collections}'"
             )
 
+    # Parse excluded database IDs
+    exclude_database_ids: list[int] | None = None
+    if args.exclude_databases:
+        try:
+            exclude_database_ids = [
+                int(db_id.strip()) for db_id in args.exclude_databases.split(",")
+            ]
+        except ValueError:
+            parser.error(
+                f"--exclude-databases must be comma-separated integers, got '{args.exclude_databases}'"
+            )
+
     # Create config object with validation
     try:
         return SyncConfig(
@@ -820,6 +894,7 @@ def get_sync_args() -> SyncConfig:
             include_archived=args.include_archived,
             include_permissions=args.include_permissions,
             root_collection_ids=root_collection_ids,
+            exclude_database_ids=exclude_database_ids,
             conflict_strategy=args.conflict,
             dry_run=args.dry_run,
             apply_permissions=args.apply_permissions,

--- a/lib/services/export_service.py
+++ b/lib/services/export_service.py
@@ -50,6 +50,7 @@ class ExportService:
         self._collection_path_map: dict[int, str] = {}
         self._processed_collections: set[int] = set()
         self._exported_cards: set[int] = set()  # Track exported cards to prevent duplicates
+        self._excluded_cards: set[int] = set()  # Cards skipped due to excluded databases
         self._dependency_chain: list[int] = (
             []
         )  # Track current dependency chain for circular detection
@@ -83,6 +84,11 @@ class ExportService:
         """Main entry point to start the export process."""
         logger.info(f"Starting Metabase export from {self.config.source_url}")
         logger.info(f"Export directory: {self.export_dir.resolve()}")
+
+        if self.config.exclude_database_ids:
+            logger.info(
+                f"Excluding cards from databases: {sorted(set(self.config.exclude_database_ids))}"
+            )
 
         self.export_dir.mkdir(parents=True, exist_ok=True)
 
@@ -130,6 +136,8 @@ class ExportService:
             logger.info("Export Summary:")
             logger.info(f"  Collections: {len(self.manifest.collections)}")
             logger.info(f"  Cards: {len(self.manifest.cards)}")
+            if self.config.exclude_database_ids:
+                logger.info(f"  Cards skipped (excluded databases): {len(self._excluded_cards)}")
             logger.info(f"  Dashboards: {len(self.manifest.dashboards)}")
             logger.info(f"  Databases: {len(self.manifest.databases)}")
             if self.config.include_permissions:
@@ -337,6 +345,44 @@ class ExportService:
                 )
 
     @staticmethod
+    def _resolve_card_database_id(card_data: dict) -> int | None:
+        """Resolves the database ID a card belongs to.
+
+        Args:
+            card_data: The card data dictionary.
+
+        Returns:
+            The database ID, or None if the card has no database reference.
+        """
+        return card_data.get("database_id") or (card_data.get("dataset_query") or {}).get(
+            "database"
+        )
+
+    def _is_card_excluded(self, card_id: int, card_data: dict) -> bool:
+        """Checks whether a card belongs to an excluded database.
+
+        Args:
+            card_id: The ID of the card being checked.
+            card_data: The card data dictionary.
+
+        Returns:
+            True if the card's database is in the configured exclusion list.
+        """
+        if not self.config.exclude_database_ids:
+            return False
+
+        db_id = self._resolve_card_database_id(card_data)
+        if db_id in self.config.exclude_database_ids:
+            self._excluded_cards.add(card_id)
+            logger.info(
+                f"Skipping card '{card_data.get('name', 'Unknown')}' (ID: {card_id}): "
+                f"database {db_id} is excluded"
+            )
+            return True
+
+        return False
+
+    @staticmethod
     def _extract_card_dependencies(card_data: dict) -> set[int]:
         """Extracts card IDs that this card depends on.
 
@@ -420,8 +466,8 @@ class ExportService:
             is_model_hint: Hint from collection listing that this is a model (model='dataset').
             dependency_chain: List of card IDs in the current dependency chain (for circular detection).
         """
-        # Skip if already exported
-        if card_id in self._exported_cards:
+        # Skip if already exported or already excluded
+        if card_id in self._exported_cards or card_id in self._excluded_cards:
             return
 
         # Initialize dependency chain if not provided
@@ -439,6 +485,10 @@ class ExportService:
 
         try:
             card_data = self.client.get_card(card_id)
+
+            # Skip cards from excluded databases before traversing their dependencies
+            if self._is_card_excluded(card_id, card_data):
+                return
 
             # Extract dependencies
             dependencies = self._extract_card_dependencies(card_data)
@@ -520,13 +570,16 @@ class ExportService:
             if card_data is None:
                 card_data = self.client.get_card(card_id)
 
+            if self._is_card_excluded(card_id, card_data):
+                return
+
             if not card_data.get("dataset_query"):
                 logger.warning(
                     f"Card ID {card_id} ('{card_data['name']}') has no dataset_query. Skipping."
                 )
                 return
 
-            db_id = card_data.get("database_id") or card_data["dataset_query"].get("database")
+            db_id = self._resolve_card_database_id(card_data)
             if db_id is None:
                 logger.warning(
                     f"Card ID {card_id} ('{card_data['name']}') has no database ID. Skipping."
@@ -624,7 +677,7 @@ class ExportService:
 
             # Export all card dependencies
             for card_id in card_ids:
-                if card_id not in self._exported_cards:
+                if card_id not in self._exported_cards and card_id not in self._excluded_cards:
                     logger.info(
                         f"     Exporting card {card_id} (required by dashboard {dashboard_id})"
                     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,7 +223,7 @@ exclude_lines = [
 precision = 2
 show_missing = true
 # Coverage thresholds - fail if coverage is below these percentages
-fail_under = 85
+fail_under = 95
 skip_covered = false
 skip_empty = true
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -54,7 +54,7 @@ exclude_lines =
 precision = 2
 show_missing = True
 # Coverage thresholds - fail if coverage is below these percentages
-fail_under = 85
+fail_under = 95
 skip_covered = False
 skip_empty = True
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,6 +60,7 @@ class TestExportConfig:
         assert config.include_dashboards is False
         assert config.include_archived is False
         assert config.root_collection_ids is None
+        assert config.exclude_database_ids is None
         assert config.log_level == "INFO"
 
     def test_export_config_with_session_token(self):
@@ -242,6 +243,52 @@ class TestExportConfigValidation:
         )
 
         assert config.root_collection_ids is None
+
+    def test_exclude_database_ids_accepted(self):
+        """Test that valid excluded database IDs are accepted."""
+        config = ExportConfig(
+            source_url="https://example.com",
+            export_dir="./export",
+            source_session_token="token123",
+            exclude_database_ids=[4, 24, 39],
+        )
+
+        assert config.exclude_database_ids == [4, 24, 39]
+
+    def test_negative_exclude_database_ids(self):
+        """Test that negative excluded database IDs are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            ExportConfig(
+                source_url="https://example.com",
+                export_dir="./export",
+                source_session_token="token123",
+                exclude_database_ids=[4, -24],
+            )
+
+        assert "positive" in str(exc_info.value).lower()
+
+    def test_zero_exclude_database_id(self):
+        """Test that zero excluded database IDs are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            ExportConfig(
+                source_url="https://example.com",
+                export_dir="./export",
+                source_session_token="token123",
+                exclude_database_ids=[0],
+            )
+
+        assert "positive" in str(exc_info.value).lower()
+
+    def test_empty_exclude_database_ids_becomes_none(self):
+        """Test that empty excluded database IDs list becomes None."""
+        config = ExportConfig(
+            source_url="https://example.com",
+            export_dir="./export",
+            source_session_token="token123",
+            exclude_database_ids=[],
+        )
+
+        assert config.exclude_database_ids is None
 
     def test_extra_fields_rejected(self):
         """Test that extra fields are rejected."""
@@ -542,6 +589,54 @@ class TestGetExportArgs:
         assert config.source_url == "https://cli.example.com"
         # CLI session token should be used
         assert config.source_session_token == "session-token"
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch(
+        "sys.argv",
+        [
+            "export_metabase.py",
+            "--source-url",
+            "https://cli.example.com",
+            "--source-session",
+            "session-token",
+            "--export-dir",
+            "./cli_export",
+            "--exclude-databases",
+            "4,24,39",
+        ],
+    )
+    def test_get_export_args_exclude_databases(self):
+        """Test parsing --exclude-databases into a list of integers."""
+        from lib.config import get_export_args
+
+        config = get_export_args()
+
+        assert config.exclude_database_ids == [4, 24, 39]
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch(
+        "sys.argv",
+        [
+            "export_metabase.py",
+            "--source-url",
+            "https://cli.example.com",
+            "--source-session",
+            "session-token",
+            "--export-dir",
+            "./cli_export",
+            "--exclude-databases",
+            "a,b",
+        ],
+    )
+    def test_get_export_args_exclude_databases_invalid(self, capsys):
+        """Test that non-integer --exclude-databases values exit with an error."""
+        from lib.config import get_export_args
+
+        with pytest.raises(SystemExit):
+            get_export_args()
+
+        captured = capsys.readouterr()
+        assert "--exclude-databases must be comma-separated integers" in captured.err
 
 
 class TestGetImportArgs:

--- a/tests/test_config_cli_errors.py
+++ b/tests/test_config_cli_errors.py
@@ -1,0 +1,381 @@
+"""Unit tests for the CLI argument error paths in lib/config.py.
+
+tests/test_config.py covers successful parsing and model validation. This module
+targets the parser.error() branches — missing required URLs, unparsable version
+strings, malformed comma-separated ID lists and both failure branches around
+config construction — plus the validators that reject bad enum values.
+
+Every CLI test neutralises python-dotenv so the repository's own .env file cannot
+leak values into the parsed configuration.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from lib.config import (
+    ConfigValidationError,
+    ExportConfig,
+    ImportConfig,
+    SyncConfig,
+    _validate_url,
+    get_export_args,
+    get_import_args,
+    get_sync_args,
+)
+
+
+def run_cli(func, argv: list[str], env: dict[str, str] | None = None):
+    """Invoke a get_*_args function with a controlled environment and argv."""
+    with (
+        patch.dict(os.environ, env or {}, clear=True),
+        patch("lib.config.load_dotenv"),
+        patch("lib.config.find_dotenv", return_value=""),
+        patch("sys.argv", argv),
+    ):
+        return func()
+
+
+def assert_cli_error(func, argv, capsys, expected: str, env: dict[str, str] | None = None) -> None:
+    """Assert that the CLI exits and writes the expected message to stderr."""
+    with pytest.raises(SystemExit):
+        run_cli(func, argv, env)
+
+    assert expected in capsys.readouterr().err
+
+
+# ============================================================================
+# Field validators
+# ============================================================================
+
+
+class TestUrlValidator:
+    """Tests for the shared _validate_url helper."""
+
+    def test_rejects_url_without_host(self):
+        with pytest.raises(ConfigValidationError, match="must include a host"):
+            _validate_url("https://", "source_url")
+
+    def test_rejects_non_http_scheme(self):
+        with pytest.raises(ConfigValidationError, match="must use http or https scheme"):
+            _validate_url("ftp://example.com", "source_url")
+
+    def test_accepts_http_and_https(self):
+        assert _validate_url("http://example.com", "source_url") == "http://example.com"
+        assert _validate_url("https://example.com/", "source_url") == "https://example.com"
+
+
+class TestEnumValidators:
+    """Tests for log_level and conflict_strategy validation on every config model."""
+
+    def test_export_config_rejects_bad_log_level(self):
+        with pytest.raises(ValidationError, match="log_level must be one of"):
+            ExportConfig(
+                source_url="https://example.com",
+                export_dir="./export",
+                source_session_token="tok",
+                log_level="LOUD",
+            )
+
+    def test_import_config_rejects_bad_log_level(self, tmp_path):
+        with pytest.raises(ValidationError, match="log_level must be one of"):
+            ImportConfig(
+                target_url="https://example.com",
+                export_dir=str(tmp_path),
+                db_map_path=str(tmp_path / "db_map.json"),
+                target_session_token="tok",
+                log_level="LOUD",
+            )
+
+    @pytest.mark.parametrize("model", [ImportConfig, SyncConfig])
+    def test_conflict_strategy_validator_rejects_unknown_value(self, model):
+        """The field type is a Literal, so the validator is exercised directly."""
+        with pytest.raises(ConfigValidationError, match="conflict_strategy must be one of"):
+            model.validate_conflict_strategy("explode")
+
+    @pytest.mark.parametrize("model", [ImportConfig, SyncConfig])
+    def test_conflict_strategy_validator_normalises_case(self, model):
+        assert model.validate_conflict_strategy("SKIP") == "skip"
+
+    def test_sync_config_empty_id_lists_become_none(self, tmp_path):
+        """Empty lists mean 'no restriction' and are normalised to None."""
+        config = SyncConfig(
+            source_url="https://source.example.com",
+            source_session_token="tok",
+            target_url="https://target.example.com",
+            target_session_token="tok",
+            export_dir=str(tmp_path),
+            db_map_path=str(tmp_path / "db_map.json"),
+            root_collection_ids=[],
+            exclude_database_ids=[],
+        )
+
+        assert config.root_collection_ids is None
+        assert config.exclude_database_ids is None
+
+    def test_sync_config_rejects_non_positive_database_id(self, tmp_path):
+        with pytest.raises(ValidationError, match="Database IDs must be positive integers"):
+            SyncConfig(
+                source_url="https://source.example.com",
+                source_session_token="tok",
+                target_url="https://target.example.com",
+                target_session_token="tok",
+                export_dir=str(tmp_path),
+                db_map_path=str(tmp_path / "db_map.json"),
+                exclude_database_ids=[1, 0],
+            )
+
+    def test_sync_config_rejects_non_positive_collection_id(self, tmp_path):
+        with pytest.raises(ValidationError, match="Collection IDs must be positive integers"):
+            SyncConfig(
+                source_url="https://source.example.com",
+                source_session_token="tok",
+                target_url="https://target.example.com",
+                target_session_token="tok",
+                export_dir=str(tmp_path),
+                db_map_path=str(tmp_path / "db_map.json"),
+                root_collection_ids=[-1],
+            )
+
+
+# ============================================================================
+# get_export_args
+# ============================================================================
+
+
+class TestGetExportArgsErrors:
+    """Tests for the parser.error() paths in get_export_args."""
+
+    BASE = [
+        "export_metabase.py",
+        "--export-dir",
+        "./export",
+        "--source-session",
+        "tok",
+        "--source-url",
+        "https://s.example.com",
+    ]
+
+    def test_missing_source_url(self, capsys):
+        assert_cli_error(
+            get_export_args,
+            ["export_metabase.py", "--export-dir", "./export"],
+            capsys,
+            "--source-url is required",
+        )
+
+    def test_invalid_metabase_version_from_env(self, capsys):
+        """--metabase-version is constrained by argparse; the env var is not."""
+        assert_cli_error(
+            get_export_args,
+            self.BASE,
+            capsys,
+            "Unsupported Metabase version 'v99'",
+            env={"MB_METABASE_VERSION": "v99"},
+        )
+
+    def test_invalid_root_collections(self, capsys):
+        assert_cli_error(
+            get_export_args,
+            self.BASE + ["--root-collections", "1,x"],
+            capsys,
+            "--root-collections must be comma-separated integers",
+        )
+
+    def test_config_validation_error_is_reported(self, capsys):
+        """A bare ConfigValidationError surfaces with its own message."""
+        with patch(
+            "lib.config.ExportConfig",
+            side_effect=ConfigValidationError("export_dir is not writable"),
+        ):
+            assert_cli_error(get_export_args, self.BASE, capsys, "export_dir is not writable")
+
+    def test_pydantic_error_is_reported(self, capsys):
+        """Other failures are wrapped as 'Configuration error'."""
+        with patch("lib.config.ExportConfig", side_effect=RuntimeError("model exploded")):
+            assert_cli_error(
+                get_export_args, self.BASE, capsys, "Configuration error: model exploded"
+            )
+
+    def test_model_validation_failure_is_reported(self, capsys):
+        """A real Pydantic failure (missing auth) exits with a configuration error."""
+        assert_cli_error(
+            get_export_args,
+            [
+                "export_metabase.py",
+                "--export-dir",
+                "./export",
+                "--source-url",
+                "https://s.example.com",
+            ],
+            capsys,
+            "Configuration error",
+        )
+
+    def test_valid_version_from_env_is_used(self):
+        config = run_cli(get_export_args, self.BASE, env={"MB_METABASE_VERSION": "v57"})
+        assert str(config.metabase_version) == "v57"
+
+
+# ============================================================================
+# get_import_args
+# ============================================================================
+
+
+class TestGetImportArgsErrors:
+    """Tests for the parser.error() paths in get_import_args."""
+
+    def base(self, tmp_path) -> list[str]:
+        return [
+            "import_metabase.py",
+            "--export-dir",
+            str(tmp_path),
+            "--db-map",
+            str(tmp_path / "db_map.json"),
+            "--target-session",
+            "tok",
+            "--target-url",
+            "https://t.example.com",
+        ]
+
+    def test_missing_target_url(self, tmp_path, capsys):
+        assert_cli_error(
+            get_import_args,
+            [
+                "import_metabase.py",
+                "--export-dir",
+                str(tmp_path),
+                "--db-map",
+                str(tmp_path / "db_map.json"),
+            ],
+            capsys,
+            "--target-url is required",
+        )
+
+    def test_invalid_metabase_version_from_env(self, tmp_path, capsys):
+        assert_cli_error(
+            get_import_args,
+            self.base(tmp_path),
+            capsys,
+            "Unsupported Metabase version 'v99'",
+            env={"MB_METABASE_VERSION": "v99"},
+        )
+
+    def test_config_validation_error_is_reported(self, tmp_path, capsys):
+        with patch(
+            "lib.config.ImportConfig",
+            side_effect=ConfigValidationError("db_map_path escapes the export dir"),
+        ):
+            assert_cli_error(
+                get_import_args,
+                self.base(tmp_path),
+                capsys,
+                "db_map_path escapes the export dir",
+            )
+
+    def test_pydantic_error_is_reported(self, tmp_path, capsys):
+        with patch("lib.config.ImportConfig", side_effect=RuntimeError("model exploded")):
+            assert_cli_error(
+                get_import_args,
+                self.base(tmp_path),
+                capsys,
+                "Configuration error: model exploded",
+            )
+
+
+# ============================================================================
+# get_sync_args
+# ============================================================================
+
+
+class TestGetSyncArgsErrors:
+    """Tests for the parser.error() paths in get_sync_args."""
+
+    def base(self, tmp_path, *, source_url=True, target_url=True) -> list[str]:
+        argv = [
+            "sync_metabase.py",
+            "--export-dir",
+            str(tmp_path),
+            "--db-map",
+            str(tmp_path / "db_map.json"),
+            "--source-session",
+            "tok",
+            "--target-session",
+            "tok",
+        ]
+        if source_url:
+            argv += ["--source-url", "https://s.example.com"]
+        if target_url:
+            argv += ["--target-url", "https://t.example.com"]
+        return argv
+
+    def test_missing_source_url(self, tmp_path, capsys):
+        assert_cli_error(
+            get_sync_args,
+            self.base(tmp_path, source_url=False),
+            capsys,
+            "--source-url is required",
+        )
+
+    def test_missing_target_url(self, tmp_path, capsys):
+        assert_cli_error(
+            get_sync_args,
+            self.base(tmp_path, target_url=False),
+            capsys,
+            "--target-url is required",
+        )
+
+    def test_invalid_metabase_version_from_env(self, tmp_path, capsys):
+        assert_cli_error(
+            get_sync_args,
+            self.base(tmp_path),
+            capsys,
+            "Unsupported Metabase version 'v99'",
+            env={"MB_METABASE_VERSION": "v99"},
+        )
+
+    def test_invalid_root_collections(self, tmp_path, capsys):
+        assert_cli_error(
+            get_sync_args,
+            self.base(tmp_path) + ["--root-collections", "1,x"],
+            capsys,
+            "--root-collections must be comma-separated integers",
+        )
+
+    def test_invalid_exclude_databases(self, tmp_path, capsys):
+        assert_cli_error(
+            get_sync_args,
+            self.base(tmp_path) + ["--exclude-databases", "4,x"],
+            capsys,
+            "--exclude-databases must be comma-separated integers",
+        )
+
+    def test_config_validation_error_is_reported(self, tmp_path, capsys):
+        with patch(
+            "lib.config.SyncConfig",
+            side_effect=ConfigValidationError("source_url must include a host"),
+        ):
+            assert_cli_error(
+                get_sync_args, self.base(tmp_path), capsys, "source_url must include a host"
+            )
+
+    def test_pydantic_error_is_reported(self, tmp_path, capsys):
+        with patch("lib.config.SyncConfig", side_effect=RuntimeError("model exploded")):
+            assert_cli_error(
+                get_sync_args,
+                self.base(tmp_path),
+                capsys,
+                "Configuration error: model exploded",
+            )
+
+    def test_exclude_databases_parsed_into_config(self, tmp_path):
+        config = run_cli(get_sync_args, self.base(tmp_path) + ["--exclude-databases", " 4 , 24 "])
+
+        assert config.exclude_database_ids == [4, 24]
+
+    def test_root_collections_parsed_into_config(self, tmp_path):
+        config = run_cli(get_sync_args, self.base(tmp_path) + ["--root-collections", "1, 2"])
+
+        assert config.root_collection_ids == [1, 2]

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -374,6 +374,138 @@ class TestModelExport:
             assert exported_card.dataset is False
 
 
+class TestExcludeDatabases:
+    """Test suite for skipping cards from excluded databases."""
+
+    @staticmethod
+    def _make_config(tmp_path, exclude_database_ids):
+        return ExportConfig(
+            source_url="https://example.com",
+            export_dir=str(tmp_path / "export"),
+            source_session_token="token",
+            exclude_database_ids=exclude_database_ids,
+        )
+
+    @staticmethod
+    def _make_card(card_id, database_id):
+        return {
+            "id": card_id,
+            "name": f"Card {card_id}",
+            "database_id": database_id,
+            "dataset_query": {"database": database_id, "type": "query", "query": {}},
+        }
+
+    def test_excluded_card_not_exported(self, tmp_path):
+        """Test that a card from an excluded database is skipped entirely."""
+        config = self._make_config(tmp_path, exclude_database_ids=[4])
+
+        with patch("lib.services.export_service.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_card.return_value = self._make_card(100, database_id=4)
+            mock_client_class.return_value = mock_client
+
+            exporter = MetabaseExporter(config)
+            exporter._export_card_with_dependencies(100, "test-collection")
+
+            assert exporter.manifest.cards == []
+            assert 100 in exporter._excluded_cards
+            # No card file must be written
+            assert not list(Path(config.export_dir).rglob("card_*.json"))
+
+    def test_non_excluded_card_still_exported(self, tmp_path):
+        """Test that cards from other databases are exported normally."""
+        config = self._make_config(tmp_path, exclude_database_ids=[4])
+
+        with patch("lib.services.export_service.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_card.return_value = self._make_card(100, database_id=1)
+            mock_client_class.return_value = mock_client
+
+            exporter = MetabaseExporter(config)
+            exporter._export_card_with_dependencies(100, "test-collection")
+
+            assert len(exporter.manifest.cards) == 1
+            assert exporter.manifest.cards[0].id == 100
+            assert exporter._excluded_cards == set()
+
+    def test_no_exclusion_when_flag_absent(self, tmp_path):
+        """Test that no cards are skipped when exclude_database_ids is None."""
+        config = self._make_config(tmp_path, exclude_database_ids=None)
+
+        with patch("lib.services.export_service.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_card.return_value = self._make_card(100, database_id=4)
+            mock_client_class.return_value = mock_client
+
+            exporter = MetabaseExporter(config)
+            exporter._export_card_with_dependencies(100, "test-collection")
+
+            assert len(exporter.manifest.cards) == 1
+            assert exporter.manifest.cards[0].database_id == 4
+
+    def test_excluded_card_dependencies_not_fetched(self, tmp_path):
+        """Test that dependencies of an excluded card are not traversed."""
+        config = self._make_config(tmp_path, exclude_database_ids=[4])
+
+        excluded_card = self._make_card(100, database_id=4)
+        excluded_card["dataset_query"]["query"] = {"source-table": "card__55"}
+
+        with patch("lib.services.export_service.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_card.return_value = excluded_card
+            mock_client_class.return_value = mock_client
+
+            exporter = MetabaseExporter(config)
+            exporter._export_card_with_dependencies(100, "test-collection")
+
+            # Only the excluded card itself is fetched; its dependency (55) is not
+            mock_client.get_card.assert_called_once_with(100)
+            assert exporter.manifest.cards == []
+
+    def test_exclusion_resolves_database_from_dataset_query(self, tmp_path):
+        """Test that the database ID falls back to dataset_query when database_id is absent."""
+        config = self._make_config(tmp_path, exclude_database_ids=[4])
+
+        card = self._make_card(100, database_id=4)
+        del card["database_id"]
+
+        with patch("lib.services.export_service.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_card.return_value = card
+            mock_client_class.return_value = mock_client
+
+            exporter = MetabaseExporter(config)
+            exporter._export_card_with_dependencies(100, "test-collection")
+
+            assert exporter.manifest.cards == []
+            assert 100 in exporter._excluded_cards
+
+    def test_dashboard_keeps_excluded_card_reference(self, tmp_path):
+        """Test that dashboards export fully, listing excluded cards without exporting them."""
+        config = self._make_config(tmp_path, exclude_database_ids=[4])
+
+        with patch("lib.services.export_service.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_dashboard.return_value = {
+                "id": 1,
+                "name": "Test Dashboard",
+                "collection_id": 10,
+                "dashcards": [{"id": 1, "card_id": 100}],
+                "parameters": [],
+            }
+            mock_client.get_card.return_value = self._make_card(100, database_id=4)
+            mock_client_class.return_value = mock_client
+
+            exporter = MetabaseExporter(config)
+            exporter._export_dashboard(1, "test-collection")
+
+            # Dashboard is exported in full; the excluded card is not
+            assert len(exporter.manifest.dashboards) == 1
+            assert exporter.manifest.dashboards[0].ordered_cards == [100]
+            assert exporter.manifest.cards == []
+            assert 100 in exporter._excluded_cards
+
+
 class TestExportDashboard:
     """Test suite for _export_dashboard method."""
 

--- a/tests/test_export_service_internals.py
+++ b/tests/test_export_service_internals.py
@@ -1,0 +1,1037 @@
+"""Unit tests for the error, recursion and edge-case paths of lib/services/export_service.py.
+
+tests/test_export.py covers the happy paths of the exporter. This module targets the
+branches that only trigger on malformed data, API failures, circular dependencies,
+archived content and database exclusion.
+"""
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from lib.client import MetabaseAPIError
+from lib.config import ExportConfig
+from lib.services.export_service import ExportService
+
+
+@pytest.fixture
+def make_service(tmp_path: Path):
+    """Return a factory building an ExportService with a mocked MetabaseClient."""
+
+    def _make(**config_overrides) -> ExportService:
+        config_kwargs = {
+            "source_url": "https://source.example.com",
+            "export_dir": str(tmp_path / "export"),
+            "source_username": "test@example.com",
+            "source_password": "password123",  # pragma: allowlist secret
+            "log_level": "INFO",
+        }
+        config_kwargs.update(config_overrides)
+        config = ExportConfig(**config_kwargs)
+
+        with patch("lib.services.export_service.MetabaseClient") as mock_client_cls:
+            service = ExportService(config)
+            service.client = mock_client_cls.return_value
+
+        service.client.get_databases.return_value = []
+        service.client.get_collections_tree.return_value = []
+        service.client.get_collection_items.return_value = {"data": []}
+        service.client.get_archived_cards.return_value = []
+        return service
+
+    return _make
+
+
+def card_payload(card_id: int, **overrides) -> dict:
+    """Build a minimal exportable card payload."""
+    payload = {
+        "id": card_id,
+        "name": f"Card {card_id}",
+        "collection_id": 1,
+        "database_id": 1,
+        "dataset_query": {"type": "query", "database": 1, "query": {"source-table": 1}},
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ============================================================================
+# run_export orchestration
+# ============================================================================
+
+
+class TestRunExport:
+    """Tests for the run_export entry point."""
+
+    def test_logs_excluded_databases(self, make_service, caplog):
+        service = make_service(exclude_database_ids=[4, 24, 4])
+
+        with caplog.at_level("INFO", logger="metabase_migration"):
+            service.run_export()
+
+        assert "Excluding cards from databases: [4, 24]" in caplog.text
+
+    def test_warns_and_returns_when_no_collections(self, make_service, caplog):
+        service = make_service()
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            service.run_export()
+
+        assert "No collections found to export." in caplog.text
+        assert not (service.export_dir / "manifest.json").exists()
+
+    def test_filters_tree_to_root_collections(self, make_service):
+        service = make_service(root_collection_ids=[2])
+        service.client.get_collections_tree.return_value = [
+            {"id": 1, "name": "Excluded"},
+            {"id": 2, "name": "Included"},
+        ]
+
+        service.run_export()
+
+        assert [c.id for c in service.manifest.collections] == [2]
+
+    def test_summary_reports_excluded_card_count(self, make_service, caplog):
+        service = make_service(exclude_database_ids=[9], include_permissions=True)
+        service.client.get_collections_tree.return_value = [{"id": 1, "name": "C"}]
+        service.client.get_collection_items.return_value = {"data": [{"id": 100, "model": "card"}]}
+        service.client.get_card.return_value = card_payload(100, database_id=9)
+        service.client.get_permission_groups.return_value = []
+        service.client.get_permissions_graph.return_value = {}
+        service.client.get_collection_permissions_graph.return_value = {}
+
+        with caplog.at_level("INFO", logger="metabase_migration"):
+            service.run_export()
+
+        assert "Cards skipped (excluded databases): 1" in caplog.text
+        assert "Permission Groups: 0" in caplog.text
+        assert service.manifest.cards == []
+
+    def test_exports_archived_cards_when_requested(self, make_service):
+        service = make_service(include_archived=True)
+        service.client.get_collections_tree.return_value = [{"id": 1, "name": "C"}]
+        service.client.get_archived_cards.return_value = [
+            {"id": 100, "name": "Old", "collection_id": 1}
+        ]
+        service.client.get_card.return_value = card_payload(100, archived=True)
+
+        service.run_export()
+
+        service.client.get_archived_cards.assert_called_once()
+        assert [c.id for c in service.manifest.cards] == [100]
+
+    def test_reraises_metabase_api_error(self, make_service, caplog):
+        service = make_service()
+        service.client.get_databases.side_effect = MetabaseAPIError("boom")
+
+        with caplog.at_level("ERROR", logger="metabase_migration"):
+            with pytest.raises(MetabaseAPIError):
+                service.run_export()
+
+        assert "A Metabase API error occurred" in caplog.text
+
+    def test_reraises_unexpected_error(self, make_service, caplog):
+        service = make_service()
+        service.client.get_databases.side_effect = RuntimeError("kaboom")
+
+        with caplog.at_level("ERROR", logger="metabase_migration"):
+            with pytest.raises(RuntimeError):
+                service.run_export()
+
+        assert "An unexpected error occurred" in caplog.text
+
+
+class TestFetchAndStoreDatabases:
+    """Tests for _fetch_and_store_databases response handling."""
+
+    def test_paginated_response_shape(self, make_service):
+        service = make_service()
+        service.client.get_databases.return_value = {"data": [{"id": 1, "name": "DB"}]}
+        service.client.get_database_metadata.return_value = {"tables": []}
+
+        service._fetch_and_store_databases()
+
+        assert service.manifest.databases == {1: "DB"}
+
+    def test_unexpected_response_shape_logs_error(self, make_service, caplog):
+        service = make_service()
+        service.client.get_databases.return_value = "nonsense"
+
+        with caplog.at_level("ERROR", logger="metabase_migration"):
+            service._fetch_and_store_databases()
+
+        assert "Unexpected databases response format" in caplog.text
+        assert service.manifest.databases == {}
+
+    def test_metadata_failure_does_not_abort(self, make_service, caplog):
+        service = make_service()
+        service.client.get_databases.return_value = [{"id": 1, "name": "A"}, {"id": 2, "name": "B"}]
+        service.client.get_database_metadata.side_effect = [
+            MetabaseAPIError("nope"),
+            {"tables": [{"id": 5, "name": "t", "fields": [{"id": 6, "name": "f"}]}]},
+        ]
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            service._fetch_and_store_databases()
+
+        assert "Failed to fetch metadata for database 1" in caplog.text
+        assert 1 not in service.manifest.database_metadata
+        assert service.manifest.database_metadata[2]["tables"][0]["fields"] == [
+            {"id": 6, "name": "f"}
+        ]
+
+
+# ============================================================================
+# collection traversal
+# ============================================================================
+
+
+class TestTraverseCollections:
+    """Tests for _traverse_collections."""
+
+    def test_skips_personal_collections(self, make_service, caplog):
+        service = make_service()
+
+        with caplog.at_level("INFO", logger="metabase_migration"):
+            service._traverse_collections([{"id": 1, "name": "Mine", "personal_owner_id": 3}])
+
+        assert "Skipping personal collection 'Mine'" in caplog.text
+        assert service.manifest.collections == []
+
+    def test_includes_explicitly_requested_personal_collection(self, make_service):
+        service = make_service(root_collection_ids=[1])
+
+        service._traverse_collections([{"id": 1, "name": "Mine", "personal_owner_id": 3}])
+
+        assert [c.id for c in service.manifest.collections] == [1]
+
+    def test_root_collection_processed_by_id_string(self, make_service):
+        service = make_service()
+
+        service._traverse_collections([{"id": "root", "name": "Our analytics"}])
+
+        service.client.get_collection_items.assert_called_once()
+        assert service.client.get_collection_items.call_args[0][0] == "root"
+        assert service.manifest.collections == []
+
+    def test_already_processed_collection_skipped(self, make_service):
+        service = make_service()
+        service._processed_collections.add(1)
+
+        service._traverse_collections([{"id": 1, "name": "C"}])
+
+        assert service.manifest.collections == []
+
+    def test_parent_id_derived_from_location(self, make_service):
+        service = make_service()
+
+        service._traverse_collections([{"id": 3, "name": "Child", "location": "/24/25/"}])
+
+        assert service.manifest.collections[0].parent_id == 25
+
+    def test_unparsable_location_leaves_parent_none(self, make_service):
+        service = make_service()
+
+        service._traverse_collections([{"id": 3, "name": "Child", "location": "/abc/"}])
+
+        assert service.manifest.collections[0].parent_id is None
+
+    def test_empty_location_leaves_parent_none(self, make_service):
+        service = make_service()
+
+        service._traverse_collections([{"id": 3, "name": "Child", "location": "/"}])
+
+        assert service.manifest.collections[0].parent_id is None
+
+    def test_recurses_into_children(self, make_service):
+        service = make_service()
+
+        service._traverse_collections(
+            [{"id": 1, "name": "Parent", "children": [{"id": 2, "name": "Child"}]}]
+        )
+
+        assert [c.id for c in service.manifest.collections] == [1, 2]
+        assert service._collection_path_map[2] == "Parent/Child"
+        assert service.manifest.collections[1].parent_id == 1
+
+    def test_empty_children_list_not_recursed(self, make_service):
+        service = make_service()
+
+        service._traverse_collections([{"id": 1, "name": "Parent", "children": []}])
+
+        assert [c.id for c in service.manifest.collections] == [1]
+
+
+class TestProcessCollectionItems:
+    """Tests for _process_collection_items."""
+
+    def test_empty_items_returns_early(self, make_service):
+        service = make_service()
+        service.client.get_collection_items.return_value = {"data": []}
+
+        service._process_collection_items(1, "path")
+
+        service.client.get_card.assert_not_called()
+
+    def test_dataset_and_metric_models_exported_as_cards(self, make_service):
+        service = make_service()
+        service.client.get_collection_items.return_value = {
+            "data": [
+                {"id": 100, "model": "dataset"},
+                {"id": 101, "model": "metric"},
+                {"id": 102, "model": "card", "type": "model"},
+            ]
+        }
+        service.client.get_card.side_effect = lambda cid: card_payload(cid)
+
+        service._process_collection_items(1, "path")
+
+        exported = {c.id: c.dataset for c in service.manifest.cards}
+        assert exported == {100: True, 101: False, 102: True}
+
+    def test_dashboard_skipped_when_not_included(self, make_service):
+        service = make_service(include_dashboards=False)
+        service.client.get_collection_items.return_value = {
+            "data": [{"id": 200, "model": "dashboard"}]
+        }
+
+        service._process_collection_items(1, "path")
+
+        service.client.get_dashboard.assert_not_called()
+
+    def test_dashboard_exported_when_included(self, make_service):
+        service = make_service(include_dashboards=True)
+        service.client.get_collection_items.return_value = {
+            "data": [{"id": 200, "model": "dashboard"}]
+        }
+        service.client.get_dashboard.return_value = {
+            "id": 200,
+            "name": "Dash",
+            "collection_id": 1,
+            "dashcards": [],
+        }
+
+        service._process_collection_items(1, "path")
+
+        assert [d.id for d in service.manifest.dashboards] == [200]
+
+    def test_api_error_is_logged_not_raised(self, make_service, caplog):
+        service = make_service()
+        service.client.get_collection_items.side_effect = MetabaseAPIError("denied")
+
+        with caplog.at_level("ERROR", logger="metabase_migration"):
+            service._process_collection_items(1, "path")
+
+        assert "Failed to process items for collection 1" in caplog.text
+
+
+# ============================================================================
+# archived cards
+# ============================================================================
+
+
+class TestExportArchivedCards:
+    """Tests for _export_archived_cards."""
+
+    def test_fetch_failure_is_logged(self, make_service, caplog):
+        service = make_service()
+        service.client.get_archived_cards.side_effect = MetabaseAPIError("nope")
+
+        with caplog.at_level("ERROR", logger="metabase_migration"):
+            service._export_archived_cards()
+
+        assert "Failed to fetch archived cards" in caplog.text
+
+    def test_card_without_id_skipped(self, make_service):
+        service = make_service()
+        service.client.get_archived_cards.return_value = [{"name": "No ID"}]
+
+        service._export_archived_cards()
+
+        service.client.get_card.assert_not_called()
+
+    def test_card_in_processed_collection_exported(self, make_service):
+        service = make_service()
+        service._processed_collections.add(4)
+        service._collection_path_map[4] = "Sales"
+        service.client.get_archived_cards.return_value = [
+            {"id": 100, "name": "Old", "collection_id": 4}
+        ]
+        service.client.get_card.return_value = card_payload(100, archived=True)
+
+        service._export_archived_cards()
+
+        assert service.manifest.cards[0].file_path.startswith("Sales/cards/")
+        assert service.manifest.cards[0].archived is True
+
+    def test_root_collection_card_skipped(self, make_service, caplog):
+        service = make_service()
+        service.client.get_archived_cards.return_value = [
+            {"id": 100, "name": "Root card", "collection_id": None}
+        ]
+
+        with caplog.at_level("DEBUG", logger="metabase_migration"):
+            service._export_archived_cards()
+
+        assert "no collection_id (root collection)" in caplog.text
+        service.client.get_card.assert_not_called()
+
+    def test_card_outside_processed_collections_skipped(self, make_service):
+        service = make_service()
+        service.client.get_archived_cards.return_value = [
+            {"id": 100, "name": "Elsewhere", "collection_id": 99}
+        ]
+
+        service._export_archived_cards()
+
+        service.client.get_card.assert_not_called()
+
+
+# ============================================================================
+# dependency extraction
+# ============================================================================
+
+
+class TestExtractCardDependencies:
+    """Tests for the static _extract_card_dependencies helper."""
+
+    def test_v56_source_table_card_reference(self):
+        card = {"dataset_query": {"query": {"source-table": "card__12"}}}
+        assert ExportService._extract_card_dependencies(card) == {12}
+
+    def test_v56_invalid_source_table_reference(self, caplog):
+        card = {"dataset_query": {"query": {"source-table": "card__oops"}}}
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            assert ExportService._extract_card_dependencies(card) == set()
+
+        assert "Invalid card reference format: card__oops" in caplog.text
+
+    def test_v57_stage_source_card(self):
+        card = {"dataset_query": {"stages": [{"source-card": 12}]}}
+        assert ExportService._extract_card_dependencies(card) == {12}
+
+    def test_v57_stage_non_dict_ignored(self):
+        card = {"dataset_query": {"stages": ["nope"]}}
+        assert ExportService._extract_card_dependencies(card) == set()
+
+    def test_v57_join_source_card(self):
+        card = {"dataset_query": {"stages": [{"joins": [{"source-card": 13}]}]}}
+        assert ExportService._extract_card_dependencies(card) == {13}
+
+    def test_v56_join_source_table_reference(self):
+        card = {"dataset_query": {"query": {"joins": [{"source-table": "card__14"}]}}}
+        assert ExportService._extract_card_dependencies(card) == {14}
+
+    def test_v56_join_invalid_reference(self, caplog):
+        card = {"dataset_query": {"query": {"joins": [{"source-table": "card__bad"}]}}}
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            assert ExportService._extract_card_dependencies(card) == set()
+
+        assert "Invalid card reference in join: card__bad" in caplog.text
+
+    def test_v57_metric_aggregation_reference(self):
+        card = {"dataset_query": {"stages": [{"aggregation": [["metric", {"lib/uuid": "u"}, 15]]}]}}
+        assert ExportService._extract_card_dependencies(card) == {15}
+
+    def test_parameter_card_dependency(self):
+        card = {
+            "dataset_query": {"query": {}},
+            "parameters": [{"values_source_config": {"card_id": 16}}],
+        }
+        assert ExportService._extract_card_dependencies(card) == {16}
+
+    def test_no_dependencies(self):
+        assert ExportService._extract_card_dependencies({"dataset_query": {}}) == set()
+
+
+# ============================================================================
+# card export with dependencies
+# ============================================================================
+
+
+class TestExportCardWithDependencies:
+    """Tests for _export_card_with_dependencies."""
+
+    def test_already_exported_card_skipped(self, make_service):
+        service = make_service()
+        service._exported_cards.add(100)
+
+        service._export_card_with_dependencies(100, "path")
+
+        service.client.get_card.assert_not_called()
+
+    def test_already_excluded_card_skipped(self, make_service):
+        service = make_service(exclude_database_ids=[9])
+        service._excluded_cards.add(100)
+
+        service._export_card_with_dependencies(100, "path")
+
+        service.client.get_card.assert_not_called()
+
+    def test_circular_dependency_breaks_cycle(self, make_service, caplog):
+        service = make_service()
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            service._export_card_with_dependencies(100, "path", dependency_chain=[100, 101])
+
+        assert "Circular dependency detected: 100 -> 101 -> 100" in caplog.text
+        service.client.get_card.assert_not_called()
+
+    def test_mutual_dependency_is_broken(self, make_service, caplog):
+        """Two cards referencing each other must not recurse forever."""
+        service = make_service()
+        cards = {
+            100: card_payload(
+                100,
+                dataset_query={
+                    "type": "query",
+                    "database": 1,
+                    "query": {"source-table": "card__101"},
+                },
+            ),
+            101: card_payload(
+                101,
+                dataset_query={
+                    "type": "query",
+                    "database": 1,
+                    "query": {"source-table": "card__100"},
+                },
+            ),
+        }
+        service.client.get_card.side_effect = lambda cid: cards[cid]
+        service._collection_path_map[1] = "Sales"
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            service._export_card_with_dependencies(100, "Sales")
+
+        assert "Circular dependency detected" in caplog.text
+        assert sorted(c.id for c in service.manifest.cards) == [100, 101]
+
+    def test_excluded_card_skips_dependency_traversal(self, make_service):
+        service = make_service(exclude_database_ids=[9])
+        service.client.get_card.return_value = card_payload(
+            100,
+            database_id=9,
+            dataset_query={"type": "query", "database": 9, "query": {"source-table": "card__101"}},
+        )
+
+        service._export_card_with_dependencies(100, "path")
+
+        assert service._excluded_cards == {100}
+        assert service.client.get_card.call_count == 1
+        assert service.manifest.cards == []
+
+    def test_dependency_placed_in_known_collection_path(self, make_service):
+        service = make_service()
+        service._collection_path_map[7] = "Shared"
+        cards = {
+            100: card_payload(
+                100,
+                dataset_query={
+                    "type": "query",
+                    "database": 1,
+                    "query": {"source-table": "card__101"},
+                },
+            ),
+            101: card_payload(101, collection_id=7),
+        }
+        service.client.get_card.side_effect = lambda cid: cards[cid]
+
+        service._export_card_with_dependencies(100, "Main")
+
+        paths = {c.id: c.file_path for c in service.manifest.cards}
+        assert paths[101].startswith("Shared/cards/")
+        assert paths[100].startswith("Main/cards/")
+
+    def test_dependency_outside_scope_goes_to_dependencies_folder(self, make_service, caplog):
+        service = make_service()
+        cards = {
+            100: card_payload(
+                100,
+                dataset_query={
+                    "type": "query",
+                    "database": 1,
+                    "query": {"source-table": "card__101"},
+                },
+            ),
+            101: card_payload(101, collection_id=None),
+        }
+        service.client.get_card.side_effect = lambda cid: cards[cid]
+
+        with caplog.at_level("INFO", logger="metabase_migration"):
+            service._export_card_with_dependencies(100, "Main")
+
+        assert "is outside export scope" in caplog.text
+        assert {c.id: c.file_path for c in service.manifest.cards}[101].startswith(
+            "dependencies/cards/"
+        )
+
+    def test_archived_dependency_warns_when_flag_not_set(self, make_service, caplog):
+        service = make_service(include_archived=False)
+        cards = {
+            100: card_payload(
+                100,
+                dataset_query={
+                    "type": "query",
+                    "database": 1,
+                    "query": {"source-table": "card__101"},
+                },
+            ),
+            101: card_payload(101, archived=True),
+        }
+        service.client.get_card.side_effect = lambda cid: cards[cid]
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            service._export_card_with_dependencies(100, "Main")
+
+        assert "Exporting anyway due to dependency" in caplog.text
+
+    def test_dependency_fetch_failure_is_logged(self, make_service, caplog):
+        service = make_service()
+
+        def get_card(cid):
+            if cid == 101:
+                raise MetabaseAPIError("gone")
+            return card_payload(
+                100,
+                dataset_query={
+                    "type": "query",
+                    "database": 1,
+                    "query": {"source-table": "card__101"},
+                },
+            )
+
+        service.client.get_card.side_effect = get_card
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            service._export_card_with_dependencies(100, "Main")
+
+        assert "Failed to fetch dependency card 101" in caplog.text
+        assert "may fail to import due to missing dependency 101" in caplog.text
+        assert [c.id for c in service.manifest.cards] == [100]
+
+    def test_already_exported_dependency_not_refetched(self, make_service):
+        service = make_service()
+        service._exported_cards.add(101)
+        service.client.get_card.return_value = card_payload(
+            100,
+            dataset_query={"type": "query", "database": 1, "query": {"source-table": "card__101"}},
+        )
+
+        service._export_card_with_dependencies(100, "Main")
+
+        assert service.client.get_card.call_count == 1
+
+    def test_card_fetch_failure_is_logged(self, make_service, caplog):
+        service = make_service()
+        service.client.get_card.side_effect = MetabaseAPIError("gone")
+
+        with caplog.at_level("ERROR", logger="metabase_migration"):
+            service._export_card_with_dependencies(100, "Main")
+
+        assert "Failed to fetch card 100 for dependency analysis" in caplog.text
+
+
+class TestExportCard:
+    """Tests for _export_card."""
+
+    def test_already_exported_returns_early(self, make_service):
+        service = make_service()
+        service._exported_cards.add(100)
+
+        service._export_card(100, "path")
+
+        service.client.get_card.assert_not_called()
+
+    def test_fetches_card_when_not_provided(self, make_service):
+        service = make_service()
+        service.client.get_card.return_value = card_payload(100)
+
+        service._export_card(100, "path")
+
+        service.client.get_card.assert_called_once_with(100)
+        assert [c.id for c in service.manifest.cards] == [100]
+
+    def test_excluded_database_card_not_written(self, make_service, caplog):
+        service = make_service(exclude_database_ids=[9])
+
+        with caplog.at_level("INFO", logger="metabase_migration"):
+            service._export_card(100, "path", card_payload(100, database_id=9))
+
+        assert "database 9 is excluded" in caplog.text
+        assert service.manifest.cards == []
+        assert service._excluded_cards == {100}
+
+    def test_database_id_resolved_from_dataset_query(self, make_service):
+        """Cards without a top-level database_id fall back to dataset_query.database."""
+        service = make_service()
+        card = card_payload(100)
+        del card["database_id"]
+
+        service._export_card(100, "path", card)
+
+        assert service.manifest.cards[0].database_id == 1
+
+    def test_card_without_dataset_query_skipped(self, make_service, caplog):
+        service = make_service()
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            service._export_card(100, "path", {"id": 100, "name": "Empty", "dataset_query": None})
+
+        assert "has no dataset_query" in caplog.text
+        assert service.manifest.cards == []
+
+    def test_card_without_database_id_skipped(self, make_service, caplog):
+        service = make_service()
+        card = {"id": 100, "name": "No DB", "dataset_query": {"type": "native"}}
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            service._export_card(100, "path", card)
+
+        assert "has no database ID" in caplog.text
+        assert service.manifest.cards == []
+
+    def test_legacy_dataset_flag_marks_model(self, make_service):
+        service = make_service()
+
+        service._export_card(100, "path", card_payload(100, dataset=True))
+
+        assert service.manifest.cards[0].dataset is True
+
+    def test_api_error_is_logged(self, make_service, caplog):
+        service = make_service()
+        service.client.get_card.side_effect = MetabaseAPIError("denied")
+
+        with caplog.at_level("ERROR", logger="metabase_migration"):
+            service._export_card(100, "path")
+
+        assert "Failed to export card ID 100" in caplog.text
+
+    def test_unexpected_error_is_logged(self, make_service, caplog):
+        service = make_service()
+
+        with patch("lib.services.export_service.write_json_file", side_effect=OSError("disk full")):
+            with caplog.at_level("ERROR", logger="metabase_migration"):
+                service._export_card(100, "path", card_payload(100))
+
+        assert "An unexpected error occurred while exporting card ID 100" in caplog.text
+        assert service.manifest.cards == []
+
+
+# ============================================================================
+# dashboards
+# ============================================================================
+
+
+class TestExportDashboard:
+    """Tests for _export_dashboard."""
+
+    def test_archived_dashboard_404_is_skipped(self, make_service, caplog):
+        service = make_service()
+        service.client.get_dashboard.side_effect = MetabaseAPIError(
+            "Dashboard is archived", status_code=404
+        )
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            service._export_dashboard(200, "path")
+
+        assert "Skipping archived dashboard ID 200" in caplog.text
+        assert service.manifest.dashboards == []
+
+    def test_other_api_errors_are_reraised(self, make_service):
+        service = make_service()
+        service.client.get_dashboard.side_effect = MetabaseAPIError("denied", status_code=403)
+
+        with pytest.raises(MetabaseAPIError):
+            service._export_dashboard(200, "path")
+
+    def test_non_404_not_found_message_reraised(self, make_service):
+        service = make_service()
+        service.client.get_dashboard.side_effect = MetabaseAPIError("not found", status_code=404)
+
+        with pytest.raises(MetabaseAPIError):
+            service._export_dashboard(200, "path")
+
+    def test_dashcards_without_card_id_ignored(self, make_service):
+        service = make_service()
+        service.client.get_dashboard.return_value = {
+            "id": 200,
+            "name": "Dash",
+            "collection_id": 1,
+            "dashcards": [{"id": 1, "card_id": None}, {"id": 2}],
+        }
+
+        service._export_dashboard(200, "path")
+
+        assert service.manifest.dashboards[0].ordered_cards == []
+
+    def test_parameter_source_card_added_as_dependency(self, make_service, caplog):
+        service = make_service()
+        service.client.get_dashboard.return_value = {
+            "id": 200,
+            "name": "Dash",
+            "collection_id": 1,
+            "dashcards": [],
+            "parameters": [
+                {"name": "Category", "values_source_config": {"card_id": 100}},
+                {"name": "Static", "values_source_config": {"values": []}},
+                {"name": "NoConfig"},
+            ],
+        }
+        service.client.get_card.return_value = card_payload(100)
+
+        with caplog.at_level("INFO", logger="metabase_migration"):
+            service._export_dashboard(200, "path")
+
+        assert "references card 100 - will be exported as dependency" in caplog.text
+        assert service.manifest.dashboards[0].ordered_cards == [100]
+
+    def test_duplicate_parameter_card_not_added_twice(self, make_service):
+        service = make_service()
+        service.client.get_dashboard.return_value = {
+            "id": 200,
+            "name": "Dash",
+            "collection_id": 1,
+            "dashcards": [{"id": 1, "card_id": 100}],
+            "parameters": [{"name": "P", "values_source_config": {"card_id": 100}}],
+        }
+        service.client.get_card.return_value = card_payload(100)
+
+        service._export_dashboard(200, "path")
+
+        assert service.manifest.dashboards[0].ordered_cards == [100]
+
+    def test_card_in_known_collection_uses_its_path(self, make_service):
+        service = make_service()
+        service._collection_path_map[7] = "Shared"
+        service.client.get_dashboard.return_value = {
+            "id": 200,
+            "name": "Dash",
+            "collection_id": 1,
+            "dashcards": [{"id": 1, "card_id": 100}],
+        }
+        service.client.get_card.return_value = card_payload(100, collection_id=7)
+
+        service._export_dashboard(200, "path")
+
+        assert service.manifest.cards[0].file_path.startswith("Shared/cards/")
+
+    def test_card_outside_scope_uses_dependencies_folder(self, make_service, caplog):
+        service = make_service()
+        service.client.get_dashboard.return_value = {
+            "id": 200,
+            "name": "Dash",
+            "collection_id": 1,
+            "dashcards": [{"id": 1, "card_id": 100}],
+        }
+        service.client.get_card.return_value = card_payload(100, collection_id=None)
+
+        with caplog.at_level("INFO", logger="metabase_migration"):
+            service._export_dashboard(200, "path")
+
+        assert "is outside export scope" in caplog.text
+        assert service.manifest.cards[0].file_path.startswith("dependencies/cards/")
+
+    def test_already_exported_card_not_refetched(self, make_service):
+        service = make_service()
+        service._exported_cards.add(100)
+        service.client.get_dashboard.return_value = {
+            "id": 200,
+            "name": "Dash",
+            "collection_id": 1,
+            "dashcards": [{"id": 1, "card_id": 100}],
+        }
+
+        service._export_dashboard(200, "path")
+
+        service.client.get_card.assert_not_called()
+        assert service.manifest.dashboards[0].ordered_cards == [100]
+
+    def test_excluded_card_not_fetched(self, make_service):
+        service = make_service(exclude_database_ids=[9])
+        service._excluded_cards.add(100)
+        service.client.get_dashboard.return_value = {
+            "id": 200,
+            "name": "Dash",
+            "collection_id": 1,
+            "dashcards": [{"id": 1, "card_id": 100}],
+        }
+
+        service._export_dashboard(200, "path")
+
+        service.client.get_card.assert_not_called()
+        assert service.manifest.dashboards[0].ordered_cards == [100]
+
+    def test_card_fetch_failure_is_logged(self, make_service, caplog):
+        service = make_service()
+        service.client.get_dashboard.return_value = {
+            "id": 200,
+            "name": "Dash",
+            "collection_id": 1,
+            "dashcards": [{"id": 1, "card_id": 100}],
+        }
+        service.client.get_card.side_effect = MetabaseAPIError("gone")
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            service._export_dashboard(200, "path")
+
+        assert "Failed to export card 100" in caplog.text
+        assert "may fail to import due to missing card 100" in caplog.text
+        assert [d.id for d in service.manifest.dashboards] == [200]
+
+    def test_unexpected_error_is_logged(self, make_service, caplog):
+        service = make_service()
+        service.client.get_dashboard.return_value = {
+            "id": 200,
+            "name": "Dash",
+            "collection_id": 1,
+            "dashcards": [],
+        }
+
+        with patch("lib.services.export_service.write_json_file", side_effect=OSError("disk full")):
+            with caplog.at_level("ERROR", logger="metabase_migration"):
+                service._export_dashboard(200, "path")
+
+        assert "An unexpected error occurred while exporting dashboard ID 200" in caplog.text
+        assert service.manifest.dashboards == []
+
+    def test_api_error_during_export_is_logged(self, make_service, caplog):
+        service = make_service()
+        service.client.get_dashboard.return_value = {
+            "id": 200,
+            "name": "Dash",
+            "collection_id": 1,
+            "dashcards": [],
+        }
+
+        with patch(
+            "lib.services.export_service.calculate_checksum",
+            side_effect=MetabaseAPIError("boom"),
+        ):
+            with caplog.at_level("ERROR", logger="metabase_migration"):
+                service._export_dashboard(200, "path")
+
+        assert "Failed to export dashboard ID 200" in caplog.text
+
+
+# ============================================================================
+# permissions
+# ============================================================================
+
+
+class TestExportPermissions:
+    """Tests for _export_permissions."""
+
+    def test_exports_groups_and_graphs(self, make_service):
+        service = make_service()
+        service.client.get_permission_groups.return_value = [
+            {"id": 1, "name": "All Users", "member_count": 5}
+        ]
+        service.client.get_permissions_graph.return_value = {"revision": 1}
+        service.client.get_collection_permissions_graph.return_value = {"revision": 2}
+
+        service._export_permissions()
+
+        assert service.manifest.permission_groups[0].member_count == 5
+        assert service.manifest.permissions_graph == {"revision": 1}
+        assert service.manifest.collection_permissions_graph == {"revision": 2}
+
+    def test_api_error_does_not_abort_export(self, make_service, caplog):
+        service = make_service()
+        service.client.get_permission_groups.side_effect = MetabaseAPIError("denied")
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            service._export_permissions()
+
+        assert "Failed to export permissions" in caplog.text
+        assert "The export will continue without permissions data." in caplog.text
+
+    def test_unexpected_error_does_not_abort_export(self, make_service, caplog):
+        service = make_service()
+        service.client.get_permission_groups.side_effect = RuntimeError("kaboom")
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            service._export_permissions()
+
+        assert "An unexpected error occurred while exporting permissions" in caplog.text
+
+
+# ============================================================================
+# exclusion helpers
+# ============================================================================
+
+
+class TestExclusionHelpers:
+    """Tests for _resolve_card_database_id and _is_card_excluded."""
+
+    def test_resolve_prefers_top_level_database_id(self):
+        assert (
+            ExportService._resolve_card_database_id(
+                {"database_id": 3, "dataset_query": {"database": 4}}
+            )
+            == 3
+        )
+
+    def test_resolve_falls_back_to_dataset_query(self):
+        assert ExportService._resolve_card_database_id({"dataset_query": {"database": 4}}) == 4
+
+    def test_resolve_handles_missing_dataset_query(self):
+        assert ExportService._resolve_card_database_id({"name": "x"}) is None
+
+    def test_resolve_handles_null_dataset_query(self):
+        assert ExportService._resolve_card_database_id({"dataset_query": None}) is None
+
+    def test_not_excluded_without_configuration(self, make_service):
+        service = make_service()
+        assert service._is_card_excluded(1, {"database_id": 9}) is False
+        assert service._excluded_cards == set()
+
+    def test_not_excluded_when_database_not_listed(self, make_service):
+        service = make_service(exclude_database_ids=[9])
+        assert service._is_card_excluded(1, {"database_id": 1}) is False
+        assert service._excluded_cards == set()
+
+    def test_excluded_card_is_tracked(self, make_service):
+        service = make_service(exclude_database_ids=[9])
+        assert service._is_card_excluded(1, {"database_id": 9}) is True
+        assert service._excluded_cards == {1}
+
+
+def test_manifest_metadata_omits_version_when_absent(tmp_path):
+    """_initialize_manifest tolerates a config dump without metabase_version."""
+    config = ExportConfig(
+        source_url="https://source.example.com",
+        export_dir=str(tmp_path / "export"),
+        source_session_token="tok",
+    )
+    with patch("lib.services.export_service.MetabaseClient"):
+        with patch.object(
+            ExportConfig, "model_dump", return_value={"source_url": config.source_url}
+        ):
+            service = ExportService(config)
+
+    assert "metabase_version" not in service.manifest.meta.cli_args
+    assert service.manifest.meta.metabase_version == "v56"
+
+
+def test_client_constructed_from_config(tmp_path):
+    """The service wires every credential from the config into the client."""
+    config = ExportConfig(
+        source_url="https://source.example.com",
+        export_dir=str(tmp_path / "export"),
+        source_personal_token="pat",
+    )
+    with patch("lib.services.export_service.MetabaseClient") as mock_client_cls:
+        ExportService(config)
+
+    mock_client_cls.assert_called_once_with(
+        base_url="https://source.example.com",
+        username=None,
+        password=None,
+        session_token=None,
+        personal_token="pat",
+    )
+    assert isinstance(mock_client_cls.return_value, Mock)

--- a/tests/test_id_mapper.py
+++ b/tests/test_id_mapper.py
@@ -1,0 +1,238 @@
+"""Unit tests for lib/remapping/id_mapper.py.
+
+Covers ID resolution, the property accessors and build_table_and_field_mappings,
+including the paths taken when metadata is missing, unmapped or unfetchable.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from lib.client import MetabaseAPIError
+from lib.models import DatabaseMap, Manifest, ManifestMeta
+from lib.remapping.id_mapper import IDMapper
+
+
+def make_manifest(
+    databases: dict[int, str] | None = None,
+    database_metadata: dict | None = None,
+) -> Manifest:
+    """Build a manifest with the given databases and metadata."""
+    manifest = Manifest(
+        meta=ManifestMeta(
+            source_url="https://source.example.com",
+            export_timestamp="2025-01-01T00:00:00",
+            tool_version="1.0.0",
+            cli_args={},
+        ),
+        databases=databases or {},
+    )
+    manifest.database_metadata = database_metadata or {}
+    return manifest
+
+
+@pytest.fixture
+def mapper() -> IDMapper:
+    """An IDMapper with db 1 mapped by id and db 2 mapped by name."""
+    manifest = make_manifest({1: "Sales", 2: "Analytics"})
+    db_map = DatabaseMap(by_id={"1": 10}, by_name={"Analytics": 20})
+    return IDMapper(manifest, db_map)
+
+
+class TestDatabaseResolution:
+    """Tests for resolve_db_id."""
+
+    def test_by_id_takes_precedence(self):
+        manifest = make_manifest({1: "Sales"})
+        mapper = IDMapper(manifest, DatabaseMap(by_id={"1": 10}, by_name={"Sales": 99}))
+        assert mapper.resolve_db_id(1) == 10
+
+    def test_falls_back_to_name(self, mapper):
+        assert mapper.resolve_db_id(2) == 20
+
+    def test_unmapped_returns_none(self, mapper):
+        assert mapper.resolve_db_id(3) is None
+
+    def test_known_database_with_unmapped_name_returns_none(self):
+        manifest = make_manifest({1: "Sales"})
+        mapper = IDMapper(manifest, DatabaseMap(by_id={}, by_name={"Other": 20}))
+        assert mapper.resolve_db_id(1) is None
+
+
+class TestIdResolution:
+    """Tests for the simple map-backed resolvers and their setters."""
+
+    def test_collection_mapping(self, mapper):
+        mapper.set_collection_mapping(1, 100)
+        assert mapper.resolve_collection_id(1) == 100
+        assert mapper.collection_map == {1: 100}
+
+    def test_collection_none_returns_none(self, mapper):
+        assert mapper.resolve_collection_id(None) is None
+
+    def test_collection_unmapped_returns_none(self, mapper):
+        assert mapper.resolve_collection_id(42) is None
+
+    def test_card_mapping(self, mapper):
+        mapper.set_card_mapping(5, 50)
+        assert mapper.resolve_card_id(5) == 50
+        assert mapper.card_map == {5: 50}
+
+    def test_card_unmapped_returns_none(self, mapper):
+        assert mapper.resolve_card_id(5) is None
+
+    def test_dashboard_mapping(self, mapper):
+        mapper.set_dashboard_mapping(7, 70)
+        assert mapper.resolve_dashboard_id(7) == 70
+        assert mapper.dashboard_map == {7: 70}
+
+    def test_dashboard_unmapped_returns_none(self, mapper):
+        assert mapper.resolve_dashboard_id(7) is None
+
+    def test_group_mapping(self, mapper):
+        mapper.set_group_mapping(3, 30)
+        assert mapper.group_map == {3: 30}
+
+    def test_table_and_field_resolution(self, mapper):
+        mapper.table_map[(1, 100)] = 1000
+        mapper.field_map[(1, 200)] = 2000
+
+        assert mapper.resolve_table_id(1, 100) == 1000
+        assert mapper.resolve_field_id(1, 200) == 2000
+
+    def test_table_and_field_unmapped_return_none(self, mapper):
+        assert mapper.resolve_table_id(1, 100) is None
+        assert mapper.resolve_field_id(1, 200) is None
+
+    def test_table_lookup_is_scoped_by_database(self, mapper):
+        mapper.table_map[(1, 100)] = 1000
+        assert mapper.resolve_table_id(2, 100) is None
+
+
+class TestBuildTableAndFieldMappings:
+    """Tests for build_table_and_field_mappings."""
+
+    def source_metadata(self) -> dict:
+        return {
+            1: {
+                "tables": [
+                    {
+                        "id": 100,
+                        "name": "orders",
+                        "fields": [{"id": 200, "name": "total"}, {"id": 201, "name": "gone"}],
+                    },
+                    {"id": 101, "name": "missing_table", "fields": []},
+                ]
+            }
+        }
+
+    def target_metadata(self) -> dict:
+        return {
+            "tables": [{"id": 1000, "name": "orders", "fields": [{"id": 2000, "name": "total"}]}]
+        }
+
+    def test_no_client_logs_warning(self, mapper, caplog):
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            mapper.build_table_and_field_mappings()
+
+        assert "No MetabaseClient set" in caplog.text
+        assert mapper.table_map == {}
+
+    def test_maps_matching_tables_and_fields(self, caplog):
+        manifest = make_manifest({1: "Sales"}, self.source_metadata())
+        client = Mock()
+        client.get_database_metadata.return_value = self.target_metadata()
+        mapper = IDMapper(manifest, DatabaseMap(by_id={"1": 10}), client)
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            mapper.build_table_and_field_mappings()
+
+        assert mapper.resolve_table_id(1, 100) == 1000
+        assert mapper.resolve_field_id(1, 200) == 2000
+        # Unmatched table and field are skipped, the table with a warning
+        assert mapper.resolve_table_id(1, 101) is None
+        assert mapper.resolve_field_id(1, 201) is None
+        assert "Table 'missing_table' (ID: 101) not found in target database 10" in caplog.text
+
+    def test_unmapped_database_is_skipped(self):
+        manifest = make_manifest({1: "Sales"}, self.source_metadata())
+        client = Mock()
+        mapper = IDMapper(manifest, DatabaseMap(by_id={}), client)
+
+        mapper.build_table_and_field_mappings()
+
+        client.get_database_metadata.assert_not_called()
+
+    def test_database_without_source_metadata_is_skipped(self):
+        manifest = make_manifest({1: "Sales"}, {})
+        client = Mock()
+        mapper = IDMapper(manifest, DatabaseMap(by_id={"1": 10}), client)
+
+        mapper.build_table_and_field_mappings()
+
+        client.get_database_metadata.assert_not_called()
+
+    def test_empty_source_table_list_is_skipped(self):
+        manifest = make_manifest({1: "Sales"}, {1: {"tables": []}})
+        client = Mock()
+        mapper = IDMapper(manifest, DatabaseMap(by_id={"1": 10}), client)
+
+        mapper.build_table_and_field_mappings()
+
+        client.get_database_metadata.assert_not_called()
+
+    def test_target_metadata_fetch_failure_is_logged(self, caplog):
+        manifest = make_manifest({1: "Sales"}, self.source_metadata())
+        client = Mock()
+        client.get_database_metadata.side_effect = MetabaseAPIError("denied")
+        mapper = IDMapper(manifest, DatabaseMap(by_id={"1": 10}), client)
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            mapper.build_table_and_field_mappings()
+
+        assert "Failed to fetch metadata for target database 10" in caplog.text
+        assert mapper.table_map == {}
+
+    def test_target_metadata_is_fetched_once_per_database(self):
+        """Two source databases mapped to the same target reuse the cached metadata."""
+        manifest = make_manifest(
+            {1: "Sales", 2: "Sales Copy"},
+            {
+                1: {"tables": [{"id": 100, "name": "orders", "fields": []}]},
+                2: {"tables": [{"id": 300, "name": "orders", "fields": []}]},
+            },
+        )
+        client = Mock()
+        client.get_database_metadata.return_value = self.target_metadata()
+        mapper = IDMapper(manifest, DatabaseMap(by_id={"1": 10, "2": 10}), client)
+
+        mapper.build_table_and_field_mappings()
+
+        assert client.get_database_metadata.call_count == 1
+        assert mapper.resolve_table_id(1, 100) == 1000
+        assert mapper.resolve_table_id(2, 300) == 1000
+
+    def test_target_table_without_fields_key(self):
+        manifest = make_manifest(
+            {1: "Sales"},
+            {1: {"tables": [{"id": 100, "name": "orders", "fields": [{"id": 200, "name": "x"}]}]}},
+        )
+        client = Mock()
+        client.get_database_metadata.return_value = {"tables": [{"id": 1000, "name": "orders"}]}
+        mapper = IDMapper(manifest, DatabaseMap(by_id={"1": 10}), client)
+
+        mapper.build_table_and_field_mappings()
+
+        assert mapper.resolve_table_id(1, 100) == 1000
+        assert mapper.resolve_field_id(1, 200) is None
+
+    def test_source_table_without_fields_key(self):
+        manifest = make_manifest({1: "Sales"}, {1: {"tables": [{"id": 100, "name": "orders"}]}})
+        client = Mock()
+        client.get_database_metadata.return_value = self.target_metadata()
+        mapper = IDMapper(manifest, DatabaseMap(by_id={"1": 10}), client)
+
+        mapper.build_table_and_field_mappings()
+
+        assert mapper.resolve_table_id(1, 100) == 1000
+        assert mapper.field_map == {}

--- a/tests/test_misc_coverage_gaps.py
+++ b/tests/test_misc_coverage_gaps.py
@@ -1,0 +1,334 @@
+"""Unit tests for remaining uncovered branches across small library modules.
+
+Covers the HTTP error-logging paths in the client, multi-page pagination, the
+custom JSON encoder, ImportReport's items/results synchronisation, version-config
+lookup failures and parameter-dependency extraction edge cases.
+"""
+
+import dataclasses
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+from pydantic import BaseModel
+
+from lib.client import MetabaseAPIError, MetabaseClient
+from lib.constants import MetabaseVersion
+from lib.models_core import ImportReport, ImportReportItem
+from lib.utils.file_io import CustomJsonEncoder, write_json_file
+from lib.utils.query import extract_metric_deps_from_clause, extract_parameter_card_dependencies
+from lib.version import get_version_config
+
+# ============================================================================
+# Client
+# ============================================================================
+
+
+def http_error(status_code: int, text: str, json_body=None) -> requests.exceptions.HTTPError:
+    """Build an HTTPError carrying a mock response."""
+    response = Mock()
+    response.status_code = status_code
+    response.text = text
+    if json_body is None:
+        response.json.side_effect = ValueError("not json")
+    else:
+        response.json.return_value = json_body
+    return requests.exceptions.HTTPError(response=response)
+
+
+@pytest.fixture
+def client() -> MetabaseClient:
+    """A client with authentication stubbed out."""
+    with patch.object(MetabaseClient, "_authenticate"):
+        return MetabaseClient(base_url="https://example.com", session_token="tok")
+
+
+class TestRequestErrorLogging:
+    """Tests for the HTTPError branch of MetabaseClient._request."""
+
+    def test_logs_json_request_body_and_pretty_response(self, client, caplog):
+        client._session = Mock()
+        client._session.headers = {}
+        client._session.request.return_value.raise_for_status.side_effect = http_error(
+            400, '{"errors":{"name":"required"}}', {"errors": {"name": "required"}}
+        )
+
+        with caplog.at_level("ERROR", logger="metabase_migration"):
+            with pytest.raises(MetabaseAPIError) as exc_info:
+                client._request.__wrapped__(client, "post", "/card", json={"name": "X"})
+
+        assert "Request body: {'name': 'X'}" in caplog.text
+        assert json.dumps({"errors": {"name": "required"}}, indent=2) in caplog.text
+        assert exc_info.value.status_code == 400
+
+    def test_falls_back_to_raw_text_when_response_is_not_json(self, client, caplog):
+        client._session = Mock()
+        client._session.headers = {}
+        client._session.request.return_value.raise_for_status.side_effect = http_error(
+            500, "Internal Server Error"
+        )
+
+        with caplog.at_level("ERROR", logger="metabase_migration"):
+            with pytest.raises(MetabaseAPIError):
+                client._request.__wrapped__(client, "get", "/card/1")
+
+        assert "Internal Server Error" in caplog.text
+        assert "Request body:" not in caplog.text
+
+    def test_logs_form_data_request_body(self, client, caplog):
+        client._session = Mock()
+        client._session.headers = {}
+        client._session.request.return_value.raise_for_status.side_effect = http_error(
+            422, "bad", {"message": "bad"}
+        )
+
+        with caplog.at_level("ERROR", logger="metabase_migration"):
+            with pytest.raises(MetabaseAPIError):
+                client._request.__wrapped__(client, "post", "/card", data="name=X")
+
+        assert "Request body: name=X" in caplog.text
+
+
+class TestPagination:
+    """Tests for MetabaseClient._get_paginated."""
+
+    def test_list_response_returns_immediately(self, client):
+        with patch.object(client, "_request") as mock_request:
+            mock_request.return_value.json.return_value = [{"id": 1}]
+
+            assert client._get_paginated("/card") == [{"id": 1}]
+            assert mock_request.call_count == 1
+
+    def test_follows_multiple_pages_until_total_reached(self, client):
+        pages = [
+            {"data": [{"id": 1}], "total": 2, "limit": 1},
+            {"data": [{"id": 2}], "total": 2, "limit": 1},
+        ]
+        with patch.object(client, "_request") as mock_request:
+            mock_request.return_value.json.side_effect = pages
+
+            assert client._get_paginated("/card") == [{"id": 1}, {"id": 2}]
+            assert mock_request.call_count == 2
+
+    def test_stops_when_total_is_absent(self, client):
+        with patch.object(client, "_request") as mock_request:
+            mock_request.return_value.json.return_value = {"data": [{"id": 1}]}
+
+            assert client._get_paginated("/card") == [{"id": 1}]
+            assert mock_request.call_count == 1
+
+    def test_stops_when_limit_is_zero(self, client):
+        with patch.object(client, "_request") as mock_request:
+            mock_request.return_value.json.return_value = {
+                "data": [{"id": 1}],
+                "total": 9,
+                "limit": 0,
+            }
+
+            assert client._get_paginated("/card") == [{"id": 1}]
+            assert mock_request.call_count == 1
+
+    def test_unexpected_shape_raises(self, client):
+        with patch.object(client, "_request") as mock_request:
+            mock_request.return_value.json.return_value = "nonsense"
+
+            with pytest.raises(MetabaseAPIError, match="Unexpected pagination response format"):
+                client._get_paginated("/card")
+
+
+class TestArchivedCards:
+    """Tests for MetabaseClient.get_archived_cards."""
+
+    def test_returns_list_response(self, client):
+        with patch.object(client, "_request") as mock_request:
+            mock_request.return_value.json.return_value = [{"id": 1}]
+
+            assert client.get_archived_cards() == [{"id": 1}]
+            mock_request.assert_called_once_with("get", "/card", params={"f": "archived"})
+
+    def test_non_list_response_becomes_empty_list(self, client):
+        with patch.object(client, "_request") as mock_request:
+            mock_request.return_value.json.return_value = {"data": []}
+
+            assert client.get_archived_cards() == []
+
+
+# ============================================================================
+# JSON encoding
+# ============================================================================
+
+
+class SampleModel(BaseModel):
+    """Minimal Pydantic model for encoder tests."""
+
+    name: str
+
+
+@dataclasses.dataclass
+class SampleDataclass:
+    """Minimal dataclass for encoder tests."""
+
+    value: int
+
+
+class TestCustomJsonEncoder:
+    """Tests for CustomJsonEncoder.default."""
+
+    def test_encodes_pydantic_model(self):
+        assert json.dumps(SampleModel(name="x"), cls=CustomJsonEncoder) == '{"name": "x"}'
+
+    def test_encodes_dataclass(self):
+        assert json.dumps(SampleDataclass(value=3), cls=CustomJsonEncoder) == '{"value": 3}'
+
+    def test_encodes_set_as_list(self):
+        assert json.loads(json.dumps({"ids": {1}}, cls=CustomJsonEncoder)) == {"ids": [1]}
+
+    def test_unsupported_type_raises(self):
+        with pytest.raises(TypeError):
+            json.dumps(object(), cls=CustomJsonEncoder)
+
+    def test_dataclass_type_is_not_treated_as_instance(self):
+        """A dataclass *class* (not an instance) is not serialisable."""
+        with pytest.raises(TypeError):
+            json.dumps(SampleDataclass, cls=CustomJsonEncoder)
+
+    def test_write_json_file_creates_parent_directories(self, tmp_path: Path):
+        target = tmp_path / "nested" / "deep" / "out.json"
+
+        write_json_file({"ids": {1, 2}}, target)
+
+        assert sorted(json.loads(target.read_text())["ids"]) == [1, 2]
+
+
+# ============================================================================
+# ImportReport
+# ============================================================================
+
+
+class TestImportReport:
+    """Tests for ImportReport's items/results synchronisation."""
+
+    def item(self, status: str = "created") -> ImportReportItem:
+        return ImportReportItem(
+            entity_type="card", status=status, source_id=1, target_id=10, name="X"
+        )
+
+    def test_empty_report_shares_one_list(self):
+        report = ImportReport()
+        report.add(self.item())
+
+        assert report.items is report.results
+        assert len(report.items) == 1
+        assert report.summary["cards"]["created"] == 1
+
+    def test_items_seeds_results(self):
+        seeded = [self.item()]
+        report = ImportReport(items=seeded)
+
+        assert report.results is seeded
+
+    def test_results_seeds_items(self):
+        seeded = [self.item()]
+        report = ImportReport(results=seeded)
+
+        assert report.items is seeded
+
+    def test_distinct_lists_are_both_appended_to(self):
+        results = [self.item()]
+        items: list[ImportReportItem] = [self.item("skipped")]
+        report = ImportReport(results=results, items=items)
+
+        assert report.results is not report.items
+        report.add(self.item("updated"))
+
+        assert len(report.results) == 2
+        assert len(report.items) == 2
+
+    def test_unknown_entity_type_does_not_update_summary(self):
+        report = ImportReport()
+        report.add(
+            ImportReportItem(
+                entity_type="widget", status="created", source_id=1, target_id=None, name="X"
+            )
+        )
+
+        assert report.summary["cards"]["created"] == 0
+        assert len(report.results) == 1
+
+
+# ============================================================================
+# Version configuration
+# ============================================================================
+
+
+class TestVersionConfig:
+    """Tests for get_version_config."""
+
+    @pytest.mark.parametrize("version", list(MetabaseVersion))
+    def test_supported_versions_return_config(self, version):
+        assert get_version_config(version) is not None
+
+    def test_unsupported_version_raises(self):
+        with pytest.raises(ValueError, match="Unsupported Metabase version"):
+            get_version_config("v99")  # type: ignore[arg-type]
+
+
+# ============================================================================
+# Query dependency helpers
+# ============================================================================
+
+
+class TestParameterDependencies:
+    """Tests for extract_parameter_card_dependencies."""
+
+    def test_no_parameters_key(self):
+        assert extract_parameter_card_dependencies({}) == set()
+
+    def test_null_parameters(self):
+        assert extract_parameter_card_dependencies({"parameters": None}) == set()
+
+    def test_non_dict_parameter_skipped(self):
+        assert extract_parameter_card_dependencies({"parameters": ["nope", 42]}) == set()
+
+    def test_non_dict_source_config_skipped(self):
+        card = {"parameters": [{"values_source_config": "nope"}]}
+        assert extract_parameter_card_dependencies(card) == set()
+
+    def test_non_integer_card_id_skipped(self):
+        card = {"parameters": [{"values_source_config": {"card_id": "12"}}]}
+        assert extract_parameter_card_dependencies(card) == set()
+
+    def test_collects_integer_card_ids(self):
+        card = {
+            "parameters": [
+                {"values_source_config": {"card_id": 12}},
+                {"values_source_config": {"card_id": 13}},
+            ]
+        }
+        assert extract_parameter_card_dependencies(card) == {12, 13}
+
+
+class TestMetricDependencies:
+    """Tests for extract_metric_deps_from_clause."""
+
+    def test_direct_metric_tuple(self):
+        deps: set[int] = set()
+        extract_metric_deps_from_clause(["metric", {"lib/uuid": "u"}, 15], deps)
+        assert deps == {15}
+
+    def test_nested_metric_tuple(self):
+        deps: set[int] = set()
+        extract_metric_deps_from_clause(["+", ["metric", {"lib/uuid": "u"}, 15], 1], deps)
+        assert deps == {15}
+
+    def test_non_list_clause_ignored(self):
+        deps: set[int] = set()
+        extract_metric_deps_from_clause("count", deps)
+        assert deps == set()
+
+    def test_metric_without_metadata_dict_ignored(self):
+        deps: set[int] = set()
+        extract_metric_deps_from_clause(["metric", 15], deps)
+        assert deps == set()

--- a/tests/test_query_remapper.py
+++ b/tests/test_query_remapper.py
@@ -1,0 +1,1053 @@
+"""Unit tests for lib/remapping/query_remapper.py.
+
+Covers the QueryRemapper paths that the feature-oriented suites
+(test_native_query_remapping.py, test_card_parameter_remapping.py,
+test_dashboard_filters.py) do not exercise: warning/fallback branches,
+malformed input handling, Visualizer settings, click behaviors and link cards.
+"""
+
+import pytest
+
+from lib.models import Card, DatabaseMap, Manifest, ManifestMeta
+from lib.remapping.id_mapper import IDMapper
+from lib.remapping.query_remapper import QueryRemapper
+
+
+def build_mapper(
+    db_mapping: dict[int, int] | None = None,
+    card_mapping: dict[int, int] | None = None,
+    dashboard_mapping: dict[int, int] | None = None,
+    table_mapping: dict[tuple[int, int], int] | None = None,
+    field_mapping: dict[tuple[int, int], int] | None = None,
+) -> IDMapper:
+    """Build an IDMapper pre-populated with the given mappings."""
+    db_mapping = db_mapping or {1: 10}
+
+    manifest = Manifest(
+        meta=ManifestMeta(
+            source_url="https://source.example.com",
+            export_timestamp="2025-01-01T00:00:00",
+            tool_version="1.0.0",
+            cli_args={},
+        ),
+        databases={source_id: f"DB{source_id}" for source_id in db_mapping},
+    )
+    mapper = IDMapper(manifest, DatabaseMap(by_id={str(k): v for k, v in db_mapping.items()}))
+
+    for source_id, target_id in (card_mapping or {}).items():
+        mapper.set_card_mapping(source_id, target_id)
+    for source_id, target_id in (dashboard_mapping or {}).items():
+        mapper.set_dashboard_mapping(source_id, target_id)
+    mapper.table_map.update(table_mapping or {})
+    mapper.field_map.update(field_mapping or {})
+
+    return mapper
+
+
+@pytest.fixture
+def remapper() -> QueryRemapper:
+    """A QueryRemapper with db 1->10, card 5->50, dashboard 7->70, table/field maps."""
+    return QueryRemapper(
+        build_mapper(
+            db_mapping={1: 10},
+            card_mapping={5: 50},
+            dashboard_mapping={7: 70},
+            table_mapping={(1, 100): 1000},
+            field_mapping={(1, 200): 2000},
+        )
+    )
+
+
+# ============================================================================
+# remap_card_data
+# ============================================================================
+
+
+class TestRemapCardData:
+    """Tests for the top-level remap_card_data entry point."""
+
+    def test_returns_false_when_no_database_reference(self, remapper):
+        """A card with neither database_id nor dataset_query.database is not remappable."""
+        data, success = remapper.remap_card_data({"name": "No DB", "dataset_query": {}})
+
+        assert success is False
+        assert data["name"] == "No DB"
+
+    def test_raises_on_unmapped_database(self, remapper):
+        """An unmapped source database is a fatal error at import time."""
+        with pytest.raises(ValueError, match="Unmapped database ID 99"):
+            remapper.remap_card_data({"database_id": 99, "dataset_query": {"database": 99}})
+
+    def test_sets_query_database_without_top_level_database_id(self, remapper):
+        """When database_id is absent, only dataset_query.database is rewritten."""
+        card = {"name": "Card", "dataset_query": {"database": 1, "type": "query", "query": {}}}
+
+        data, success = remapper.remap_card_data(card)
+
+        assert success is True
+        assert data["dataset_query"]["database"] == 10
+        assert "database_id" not in data
+
+    def test_does_not_mutate_input(self, remapper):
+        """remap_card_data works on a deep copy of the input."""
+        card = {"database_id": 1, "dataset_query": {"database": 1, "type": "query", "query": {}}}
+
+        remapper.remap_card_data(card)
+
+        assert card["database_id"] == 1
+        assert card["dataset_query"]["database"] == 1
+
+    def test_remaps_card_level_table_id(self, remapper):
+        """table_id at the card level is remapped through the table map."""
+        card = {
+            "database_id": 1,
+            "table_id": 100,
+            "dataset_query": {"database": 1, "type": "query", "query": {}},
+        }
+
+        data, _ = remapper.remap_card_data(card)
+
+        assert data["table_id"] == 1000
+
+    def test_keeps_unmapped_card_level_table_id(self, remapper, caplog):
+        """An unmapped table_id is kept as-is and logged as a warning."""
+        card = {
+            "database_id": 1,
+            "table_id": 999,
+            "dataset_query": {"database": 1, "type": "query", "query": {}},
+        }
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            data, _ = remapper.remap_card_data(card)
+
+        assert data["table_id"] == 999
+        assert "No table ID mapping found for source table 999" in caplog.text
+
+    def test_ignores_non_integer_table_id(self, remapper):
+        """A non-integer table_id (e.g. a card ref) is left untouched."""
+        card = {
+            "database_id": 1,
+            "table_id": "card__5",
+            "dataset_query": {"database": 1, "type": "query", "query": {}},
+        }
+
+        data, _ = remapper.remap_card_data(card)
+
+        assert data["table_id"] == "card__5"
+
+    def test_remaps_result_metadata_and_visualization_settings(self, remapper):
+        """result_metadata and visualization_settings are remapped when present."""
+        card = {
+            "database_id": 1,
+            "dataset_query": {"database": 1, "type": "query", "query": {}},
+            "result_metadata": [{"id": 200, "table_id": 100, "field_ref": ["field", 200, None]}],
+            "visualization_settings": {"graph.dimensions": [["field", 200, None]]},
+        }
+
+        data, _ = remapper.remap_card_data(card)
+
+        meta = data["result_metadata"][0]
+        assert meta["id"] == 2000
+        assert meta["table_id"] == 1000
+        assert meta["field_ref"] == ["field", 2000, None]
+        assert data["visualization_settings"]["graph.dimensions"] == [["field", 2000, None]]
+
+    def test_remaps_card_level_parameters(self, remapper):
+        """Card-level filter parameters sourcing values from another card are remapped."""
+        card = {
+            "database_id": 1,
+            "dataset_query": {"database": 1, "type": "query", "query": {}},
+            "parameters": [
+                {
+                    "name": "Category",
+                    "values_source_type": "card",
+                    "values_source_config": {"card_id": 5},
+                }
+            ],
+        }
+
+        data, _ = remapper.remap_card_data(card)
+
+        assert data["parameters"][0]["values_source_config"]["card_id"] == 50
+
+    def test_dispatches_native_v57_stage_with_string_native(self, remapper):
+        """A v57 stage whose 'native' key holds a string is treated as a native query."""
+        card = {
+            "database_id": 1,
+            "dataset_query": {
+                "database": 1,
+                "stages": [{"native": "SELECT * FROM {{#5-orders}}"}],
+            },
+        }
+
+        data, _ = remapper.remap_card_data(card)
+
+        assert data["dataset_query"]["stages"][0]["native"] == "SELECT * FROM {{#50-orders}}"
+
+
+# ============================================================================
+# _is_native_query
+# ============================================================================
+
+
+class TestIsNativeQuery:
+    """Tests for native-query detection across v56 and v57 formats."""
+
+    def test_v56_native(self, remapper):
+        assert remapper._is_native_query({"type": "native"}) is True
+
+    def test_v56_mbql(self, remapper):
+        assert remapper._is_native_query({"type": "query"}) is False
+
+    def test_v57_native_stage_type(self, remapper):
+        query = {"stages": [{"lib/type": "mbql.stage/native"}]}
+        assert remapper._is_native_query(query) is True
+
+    def test_v57_mbql_stage_type(self, remapper):
+        query = {"stages": [{"lib/type": "mbql.stage/mbql", "source-table": 1}]}
+        assert remapper._is_native_query(query) is False
+
+    def test_v57_non_dict_stage_ignored(self, remapper):
+        assert remapper._is_native_query({"stages": ["not-a-dict"]}) is False
+
+    def test_stages_not_a_list(self, remapper):
+        assert remapper._is_native_query({"stages": "nope"}) is False
+
+
+# ============================================================================
+# source-table / source-card
+# ============================================================================
+
+
+class TestSourceTableRemapping:
+    """Tests for _remap_source_table across v56 and v57 shapes."""
+
+    def test_v57_source_card_remapped(self, remapper):
+        query = {"source-card": 5}
+        remapper._remap_source_table(query, 1)
+        assert query["source-card"] == 50
+
+    def test_v57_source_card_unmapped_kept(self, remapper, caplog):
+        query = {"source-card": 404}
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            remapper._remap_source_table(query, 1)
+
+        assert query["source-card"] == 404
+        assert "No card mapping found for v57 source-card 404" in caplog.text
+
+    def test_no_source_table_key_is_noop(self, remapper):
+        query = {"aggregation": [["count"]]}
+        remapper._remap_source_table(query, 1)
+        assert query == {"aggregation": [["count"]]}
+
+    def test_v56_card_reference_remapped(self, remapper):
+        query = {"source-table": "card__5"}
+        remapper._remap_source_table(query, 1)
+        assert query["source-table"] == "card__50"
+
+    def test_table_id_unmapped_kept(self, remapper, caplog):
+        query = {"source-table": 777}
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            remapper._remap_source_table(query, 1)
+
+        assert query["source-table"] == 777
+        assert "No table ID mapping found for source table 777" in caplog.text
+
+    def test_non_card_string_source_table_untouched(self, remapper):
+        """A string source-table that is not a card ref falls through unchanged."""
+        query = {"source-table": "public.orders"}
+        remapper._remap_source_table(query, 1)
+        assert query["source-table"] == "public.orders"
+
+    def test_invalid_card_reference_logs_warning(self, remapper, caplog):
+        """A malformed 'card__' reference is reported and left alone."""
+        query = {"source-table": "card__abc"}
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            remapper._remap_source_table(query, 1)
+
+        assert query["source-table"] == "card__abc"
+        assert "Invalid card reference format: card__abc" in caplog.text
+
+    def test_unmapped_card_reference_kept(self, remapper):
+        """An unmapped card ref keeps its original value."""
+        query = {"source-table": "card__404"}
+        remapper._remap_source_table(query, 1)
+        assert query["source-table"] == "card__404"
+
+
+# ============================================================================
+# joins
+# ============================================================================
+
+
+class TestJoinRemapping:
+    """Tests for _remap_joins across v56 and v57 shapes."""
+
+    def test_v57_join_with_nested_stages(self, remapper):
+        """A join carrying its own stages remaps source tables, clauses and condition."""
+        query = {
+            "joins": [
+                {
+                    "stages": [{"source-table": 100, "filters": [["=", ["field", 200, None], 1]]}],
+                    "condition": ["=", ["field", 200, None], ["field", 200, None]],
+                }
+            ]
+        }
+
+        remapper._remap_joins(query, 1)
+
+        stage = query["joins"][0]["stages"][0]
+        assert stage["source-table"] == 1000
+        assert stage["filters"] == [["=", ["field", 2000, None], 1]]
+        assert query["joins"][0]["condition"] == [
+            "=",
+            ["field", 2000, None],
+            ["field", 2000, None],
+        ]
+
+    def test_v57_join_stages_skips_non_dict_entries(self, remapper):
+        query = {"joins": [{"stages": ["not-a-dict"]}]}
+        remapper._remap_joins(query, 1)
+        assert query["joins"][0]["stages"] == ["not-a-dict"]
+
+    def test_v57_join_stages_without_condition(self, remapper):
+        query = {"joins": [{"stages": [{"source-table": 100}]}]}
+        remapper._remap_joins(query, 1)
+        assert query["joins"][0]["stages"][0]["source-table"] == 1000
+
+    def test_v57_join_source_card(self, remapper):
+        query = {"joins": [{"source-card": 5}]}
+        remapper._remap_joins(query, 1)
+        assert query["joins"][0]["source-card"] == 50
+
+    def test_v57_join_source_card_unmapped_kept(self, remapper):
+        query = {"joins": [{"source-card": 404}]}
+        remapper._remap_joins(query, 1)
+        assert query["joins"][0]["source-card"] == 404
+
+    def test_v56_join_source_table_int(self, remapper):
+        query = {"joins": [{"source-table": 100}]}
+        remapper._remap_joins(query, 1)
+        assert query["joins"][0]["source-table"] == 1000
+
+    def test_v56_join_source_table_int_unmapped_kept(self, remapper):
+        query = {"joins": [{"source-table": 555}]}
+        remapper._remap_joins(query, 1)
+        assert query["joins"][0]["source-table"] == 555
+
+    def test_v56_join_card_reference(self, remapper):
+        query = {"joins": [{"source-table": "card__5"}]}
+        remapper._remap_joins(query, 1)
+        assert query["joins"][0]["source-table"] == "card__50"
+
+    def test_join_condition_field_ids_remapped(self, remapper):
+        query = {"joins": [{"source-table": 100, "condition": ["=", ["field", 200, None], 5]}]}
+        remapper._remap_joins(query, 1)
+        assert query["joins"][0]["condition"] == ["=", ["field", 2000, None], 5]
+
+    def test_join_without_source_table_or_card(self, remapper):
+        query = {"joins": [{"alias": "j0"}]}
+        remapper._remap_joins(query, 1)
+        assert query["joins"][0] == {"alias": "j0"}
+
+    def test_no_joins_key_is_noop(self, remapper):
+        query = {"source-table": 100}
+        remapper._remap_joins(query, 1)
+        assert query == {"source-table": 100}
+
+
+# ============================================================================
+# query clauses / MBQL dispatch
+# ============================================================================
+
+
+class TestQueryClauseRemapping:
+    """Tests for _remap_query_clauses and _remap_mbql_query dispatch."""
+
+    def test_v56_clauses_remapped(self, remapper):
+        query = {
+            "filter": ["=", ["field", 200, None], 1],
+            "aggregation": [["sum", ["field", 200, None]]],
+            "breakout": [["field", 200, None]],
+            "order-by": [["asc", ["field", 200, None]]],
+            "fields": [["field", 200, None]],
+            "expressions": {"double": ["*", ["field", 200, None], 2]},
+        }
+
+        remapper._remap_query_clauses(query, 1)
+
+        assert query["filter"] == ["=", ["field", 2000, None], 1]
+        assert query["aggregation"] == [["sum", ["field", 2000, None]]]
+        assert query["breakout"] == [["field", 2000, None]]
+        assert query["order-by"] == [["asc", ["field", 2000, None]]]
+        assert query["fields"] == [["field", 2000, None]]
+        assert query["expressions"] == {"double": ["*", ["field", 2000, None], 2]}
+
+    def test_v57_filters_plural_remapped(self, remapper):
+        query = {"filters": [["=", ["field", 200, None], 1]]}
+        remapper._remap_query_clauses(query, 1)
+        assert query["filters"] == [["=", ["field", 2000, None], 1]]
+
+    def test_mbql_dispatch_v57_stages(self, remapper):
+        dataset_query = {"stages": [{"source-table": 100, "filters": [["field", 200, None]]}]}
+        remapper._remap_mbql_query(dataset_query, 1)
+        assert dataset_query["stages"][0]["source-table"] == 1000
+        assert dataset_query["stages"][0]["filters"] == [["field", 2000, None]]
+
+    def test_mbql_dispatch_v57_skips_non_dict_stage(self, remapper):
+        dataset_query = {"stages": ["not-a-dict"]}
+        remapper._remap_mbql_query(dataset_query, 1)
+        assert dataset_query["stages"] == ["not-a-dict"]
+
+    def test_mbql_dispatch_v56_inner_query(self, remapper):
+        dataset_query = {"query": {"source-table": 100}}
+        remapper._remap_mbql_query(dataset_query, 1)
+        assert dataset_query["query"]["source-table"] == 1000
+
+    def test_mbql_dispatch_v56_empty_query_is_noop(self, remapper):
+        dataset_query = {"query": {}}
+        remapper._remap_mbql_query(dataset_query, 1)
+        assert dataset_query == {"query": {}}
+
+
+# ============================================================================
+# result_metadata
+# ============================================================================
+
+
+class TestResultMetadataRemapping:
+    """Tests for _remap_result_metadata."""
+
+    def test_non_list_returned_unchanged(self, remapper):
+        assert remapper._remap_result_metadata({"not": "a list"}, 1) == {"not": "a list"}
+
+    def test_non_dict_items_preserved(self, remapper):
+        result = remapper._remap_result_metadata(["string", 42, None], 1)
+        assert result == ["string", 42, None]
+
+    def test_unmapped_ids_kept(self, remapper):
+        result = remapper._remap_result_metadata([{"id": 999, "table_id": 888}], 1)
+        assert result == [{"id": 999, "table_id": 888}]
+
+    def test_non_integer_ids_ignored(self, remapper):
+        result = remapper._remap_result_metadata([{"id": "abc", "table_id": None}], 1)
+        assert result == [{"id": "abc", "table_id": None}]
+
+    def test_original_items_not_mutated(self, remapper):
+        metadata = [{"id": 200}]
+        remapper._remap_result_metadata(metadata, 1)
+        assert metadata == [{"id": 200}]
+
+
+# ============================================================================
+# recursive field remapping
+# ============================================================================
+
+
+class TestRecursiveFieldRemapping:
+    """Tests for remap_field_ids_recursively and _remap_list."""
+
+    def test_none_passes_through(self, remapper):
+        assert remapper.remap_field_ids_recursively(None, 1) is None
+
+    def test_primitives_pass_through(self, remapper):
+        assert remapper.remap_field_ids_recursively("text", 1) == "text"
+        assert remapper.remap_field_ids_recursively(42, 1) == 42
+
+    def test_empty_list_returned_as_is(self, remapper):
+        assert remapper.remap_field_ids_recursively([], 1) == []
+
+    def test_nested_dict_remapped(self, remapper):
+        data = {"outer": {"inner": ["field", 200, None]}}
+        assert remapper.remap_field_ids_recursively(data, 1) == {
+            "outer": {"inner": ["field", 2000, None]}
+        }
+
+    def test_field_id_alias_type(self, remapper):
+        assert remapper.remap_field_ids_recursively(["field-id", 200], 1) == ["field-id", 2000]
+
+    def test_unmapped_field_id_kept_with_warning(self, remapper, caplog):
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            result = remapper.remap_field_ids_recursively(["field", 909, None], 1)
+
+        assert result == ["field", 909, None]
+        assert "No field ID mapping found for source field 909" in caplog.text
+
+    def test_string_field_name_untouched(self, remapper):
+        """Native-query field refs use a string name and must not be remapped."""
+        assert remapper.remap_field_ids_recursively(["field", "TOTAL", None], 1) == [
+            "field",
+            "TOTAL",
+            None,
+        ]
+
+    def test_v57_field_metadata_first(self, remapper):
+        data = ["field", {"lib/uuid": "abc", "base-type": "type/Integer"}, 200]
+        assert remapper.remap_field_ids_recursively(data, 1) == [
+            "field",
+            {"lib/uuid": "abc", "base-type": "type/Integer"},
+            2000,
+        ]
+
+    def test_v57_field_metadata_first_unmapped(self, remapper, caplog):
+        data = ["field", {"lib/uuid": "abc"}, 909]
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            result = remapper.remap_field_ids_recursively(data, 1)
+
+        assert result == data
+        assert "No field ID mapping found for v57 source field 909" in caplog.text
+
+    def test_v57_metric_reference_remapped(self, remapper):
+        data = ["metric", {"lib/uuid": "abc"}, 5]
+        assert remapper.remap_field_ids_recursively(data, 1) == [
+            "metric",
+            {"lib/uuid": "abc"},
+            50,
+        ]
+
+    def test_v57_metric_reference_unmapped_kept(self, remapper, caplog):
+        data = ["metric", {"lib/uuid": "abc"}, 404]
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            result = remapper.remap_field_ids_recursively(data, 1)
+
+        assert result == data
+        assert "No card ID mapping found for metric source card 404" in caplog.text
+
+    def test_metric_without_metadata_dict_recurses(self, remapper):
+        """A ["metric", ...] clause that is not the v57 3-tuple shape recurses normally."""
+        data = ["metric", ["field", 200, None]]
+        assert remapper.remap_field_ids_recursively(data, 1) == ["metric", ["field", 2000, None]]
+
+    def test_single_element_list_recurses(self, remapper):
+        assert remapper.remap_field_ids_recursively([["field", 200, None]], 1) == [
+            ["field", 2000, None]
+        ]
+
+
+# ============================================================================
+# parameters
+# ============================================================================
+
+
+class TestParameterRemapping:
+    """Tests for remap_dashboard_parameters and its helpers."""
+
+    def test_parameter_without_source_config_untouched(self, remapper):
+        params = [{"name": "Plain", "type": "category"}]
+        assert remapper.remap_dashboard_parameters(params, []) == params
+
+    def test_non_dict_source_config_untouched(self, remapper):
+        params = [{"name": "P", "values_source_config": "not-a-dict"}]
+        assert remapper.remap_dashboard_parameters(params, []) == params
+
+    def test_source_config_without_card_id_untouched(self, remapper):
+        params = [{"name": "P", "values_source_config": {"values": ["a", "b"]}}]
+        assert remapper.remap_dashboard_parameters(params, []) == params
+
+    def test_card_id_remapped_without_value_field(self, remapper):
+        params = [{"name": "P", "values_source_config": {"card_id": 5}}]
+        result = remapper.remap_dashboard_parameters(params, [])
+        assert result[0]["values_source_config"]["card_id"] == 50
+
+    def test_value_field_remapped_using_manifest_card(self, remapper):
+        params = [
+            {
+                "name": "P",
+                "values_source_config": {"card_id": 5, "value_field": ["field", 200, None]},
+            }
+        ]
+        manifest_cards = [
+            Card(id=9, name="Other", database_id=2),
+            Card(id=5, name="Src", database_id=1),
+        ]
+
+        result = remapper.remap_dashboard_parameters(params, manifest_cards)
+
+        assert result[0]["values_source_config"]["value_field"] == ["field", 2000, None]
+
+    def test_value_field_kept_when_card_not_in_manifest(self, remapper, caplog):
+        params = [
+            {
+                "name": "P",
+                "values_source_config": {"card_id": 5, "value_field": ["field", 200, None]},
+            }
+        ]
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            result = remapper.remap_dashboard_parameters(params, [])
+
+        assert result[0]["values_source_config"]["value_field"] == ["field", 200, None]
+        assert "Could not determine database ID for card 5" in caplog.text
+
+    def test_unmapped_card_strips_source_config(self, remapper, caplog):
+        params = [
+            {
+                "name": "Broken",
+                "values_source_type": "card",
+                "values_source_config": {"card_id": 404},
+            }
+        ]
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            result = remapper.remap_dashboard_parameters(params, [])
+
+        assert "values_source_config" not in result[0]
+        assert "values_source_type" not in result[0]
+        assert "references missing card 404" in caplog.text
+
+    def test_unmapped_card_without_source_type_key(self, remapper):
+        params = [{"name": "Broken", "values_source_config": {"card_id": 404}}]
+        result = remapper.remap_dashboard_parameters(params, [])
+        assert "values_source_config" not in result[0]
+
+
+class TestDashcardParameterMappings:
+    """Tests for remap_dashcard_parameter_mappings."""
+
+    def test_card_and_target_remapped(self, remapper):
+        mappings = [{"card_id": 5, "target": ["dimension", ["field", 200, None]]}]
+
+        result = remapper.remap_dashcard_parameter_mappings(mappings, 1)
+
+        assert result[0]["card_id"] == 50
+        assert result[0]["target"] == ["dimension", ["field", 2000, None]]
+
+    def test_unmapped_card_id_kept(self, remapper):
+        result = remapper.remap_dashcard_parameter_mappings([{"card_id": 404}], 1)
+        assert result[0]["card_id"] == 404
+
+    def test_mapping_without_card_id(self, remapper):
+        result = remapper.remap_dashcard_parameter_mappings(
+            [{"target": ["dimension", ["field", 200, None]]}], 1
+        )
+        assert result[0]["target"] == ["dimension", ["field", 2000, None]]
+
+    def test_target_not_remapped_without_source_db(self, remapper):
+        result = remapper.remap_dashcard_parameter_mappings(
+            [{"target": ["dimension", ["field", 200, None]]}], None
+        )
+        assert result[0]["target"] == ["dimension", ["field", 200, None]]
+
+    def test_original_mappings_not_mutated(self, remapper):
+        mappings = [{"card_id": 5}]
+        remapper.remap_dashcard_parameter_mappings(mappings, 1)
+        assert mappings[0]["card_id"] == 5
+
+
+# ============================================================================
+# native queries
+# ============================================================================
+
+
+class TestRemapNativeQuery:
+    """Tests for the standalone remap_native_query entry point."""
+
+    def test_v56_sql_and_template_tags(self, remapper):
+        card = {
+            "database_id": 1,
+            "dataset_query": {
+                "type": "native",
+                "database": 1,
+                "native": {
+                    "query": "SELECT * FROM {{#5-orders}}",
+                    "template-tags": {
+                        "5-orders": {"type": "card", "card-id": 5, "name": "5-orders"}
+                    },
+                },
+            },
+        }
+
+        result = remapper.remap_native_query(card)
+
+        native = result["dataset_query"]["native"]
+        assert native["query"] == "SELECT * FROM {{#50-orders}}"
+        assert "50-orders" in native["template-tags"]
+        assert native["template-tags"]["50-orders"]["card-id"] == 50
+
+    def test_v57_dispatch_via_lib_type(self, remapper):
+        card = {
+            "database_id": 1,
+            "dataset_query": {
+                "lib/type": "mbql/query",
+                "database": 1,
+                "stages": [
+                    {"lib/type": "mbql.stage/native", "native": "SELECT * FROM {{#5-orders}}"}
+                ],
+            },
+        }
+
+        result = remapper.remap_native_query(card)
+
+        assert result["dataset_query"]["stages"][0]["native"] == "SELECT * FROM {{#50-orders}}"
+
+    def test_missing_database_defaults_to_zero(self, remapper):
+        """A card with no resolvable database still remaps card references."""
+        card = {"dataset_query": {"type": "native", "native": {"query": "{{#5-orders}}"}}}
+
+        result = remapper.remap_native_query(card)
+
+        assert result["dataset_query"]["native"]["query"] == "{{#50-orders}}"
+
+    def test_does_not_mutate_input(self, remapper):
+        card = {
+            "database_id": 1,
+            "dataset_query": {"type": "native", "native": {"query": "{{#5-orders}}"}},
+        }
+
+        remapper.remap_native_query(card)
+
+        assert card["dataset_query"]["native"]["query"] == "{{#5-orders}}"
+
+    def test_v56_native_not_a_dict_is_noop(self, remapper):
+        query = {"type": "native", "native": "raw string"}
+        remapper._remap_native_query_v56(query, 1)
+        assert query["native"] == "raw string"
+
+    def test_v56_native_without_query_string(self, remapper):
+        query = {"type": "native", "native": {"collection": "orders"}}
+        remapper._remap_native_query_v56(query, 1)
+        assert query["native"] == {"collection": "orders"}
+
+    def test_v56_template_tags_not_a_dict(self, remapper):
+        query = {"type": "native", "native": {"query": "x", "template-tags": []}}
+        remapper._remap_native_query_v56(query, 1)
+        assert query["native"]["template-tags"] == []
+
+    def test_v57_stages_not_a_list_is_noop(self, remapper):
+        query = {"lib/type": "mbql/query", "stages": "nope"}
+        remapper._remap_native_query_v57(query, 1)
+        assert query["stages"] == "nope"
+
+    def test_v57_skips_non_dict_stages(self, remapper):
+        query = {"lib/type": "mbql/query", "stages": ["not-a-dict"]}
+        remapper._remap_native_query_v57(query, 1)
+        assert query["stages"] == ["not-a-dict"]
+
+    def test_v57_stage_without_string_native(self, remapper):
+        query = {"lib/type": "mbql/query", "stages": [{"native": {"query": "x"}}]}
+        remapper._remap_native_query_v57(query, 1)
+        assert query["stages"][0]["native"] == {"query": "x"}
+
+    def test_v57_stage_without_template_tags(self, remapper):
+        query = {"lib/type": "mbql/query", "stages": [{"native": "{{#5-orders}}"}]}
+        remapper._remap_native_query_v57(query, 1)
+        assert query["stages"][0]["native"] == "{{#50-orders}}"
+
+    def test_unmapped_sql_reference_kept(self, remapper, caplog):
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            result = remapper._remap_sql_card_references("SELECT * FROM {{#404-missing}}")
+
+        assert result == "SELECT * FROM {{#404-missing}}"
+        assert "No card mapping found for card reference" in caplog.text
+
+
+class TestTemplateTags:
+    """Tests for _remap_template_tags and _remap_tag_name."""
+
+    def test_non_dict_tag_data_preserved(self, remapper):
+        result = remapper._remap_template_tags({"tag": "not-a-dict"}, 1)
+        assert result == {"tag": "not-a-dict"}
+
+    def test_card_tag_without_card_id_preserved(self, remapper):
+        tags = {"tag": {"type": "card"}}
+        assert remapper._remap_template_tags(tags, 1) == tags
+
+    def test_card_tag_unmapped_kept(self, remapper, caplog):
+        tags = {"404-x": {"type": "card", "card-id": 404}}
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            result = remapper._remap_template_tags(tags, 1)
+
+        assert result == tags
+        assert "No card mapping found for template tag '404-x'" in caplog.text
+
+    def test_card_tag_renames_name_and_display_name(self, remapper):
+        tags = {
+            "#5-orders": {
+                "type": "card",
+                "card-id": 5,
+                "name": "#5-orders",
+                "display-name": "#5 Orders",
+            }
+        }
+
+        result = remapper._remap_template_tags(tags, 1)
+
+        assert "#50-orders" in result
+        assert result["#50-orders"]["name"] == "#50-orders"
+        assert result["#50-orders"]["display-name"] == "#50 Orders"
+
+    def test_dimension_tag_field_remapped(self, remapper):
+        tags = {"cat": {"type": "dimension", "dimension": ["field", 200, None]}}
+
+        result = remapper._remap_template_tags(tags, 1)
+
+        assert result["cat"]["dimension"] == ["field", 2000, None]
+
+    def test_temporal_unit_tag_field_remapped(self, remapper):
+        tags = {"unit": {"type": "temporal-unit", "dimension": ["field", 200, None]}}
+
+        result = remapper._remap_template_tags(tags, 1)
+
+        assert result["unit"]["dimension"] == ["field", 2000, None]
+
+    def test_dimension_tag_without_list_dimension_preserved(self, remapper):
+        tags = {"cat": {"type": "dimension", "dimension": None}}
+        assert remapper._remap_template_tags(tags, 1) == tags
+
+    def test_plain_text_tag_preserved(self, remapper):
+        tags = {"x": {"type": "text", "name": "x"}}
+        assert remapper._remap_template_tags(tags, 1) == tags
+
+    def test_tag_name_without_card_id_prefix_unchanged(self, remapper):
+        assert remapper._remap_tag_name("orders-summary", 5, 50) == "orders-summary"
+
+    def test_tag_name_partial_id_not_replaced(self, remapper):
+        """'55-x' must not match a source card ID of 5."""
+        assert remapper._remap_tag_name("55-x", 5, 50) == "55-x"
+
+
+# ============================================================================
+# dashcard visualization settings
+# ============================================================================
+
+
+class TestDashcardVisualizationSettings:
+    """Tests for remap_dashcard_visualization_settings and its helpers."""
+
+    def test_empty_settings_returned_as_is(self, remapper):
+        assert remapper.remap_dashcard_visualization_settings({}, 1) == {}
+        assert remapper.remap_dashcard_visualization_settings(None, 1) is None
+
+    def test_click_behavior_question_target(self, remapper):
+        settings = {"click_behavior": {"type": "link", "linkType": "question", "targetId": 5}}
+
+        result = remapper.remap_dashcard_visualization_settings(settings, None)
+
+        assert result["click_behavior"]["targetId"] == 50
+
+    def test_click_behavior_dashboard_target(self, remapper):
+        settings = {"click_behavior": {"type": "link", "linkType": "dashboard", "targetId": 7}}
+
+        result = remapper.remap_dashcard_visualization_settings(settings, None)
+
+        assert result["click_behavior"]["targetId"] == 70
+
+    def test_click_behavior_unmapped_question_kept(self, remapper, caplog):
+        settings = {"click_behavior": {"type": "link", "linkType": "question", "targetId": 404}}
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            result = remapper.remap_dashcard_visualization_settings(settings, None)
+
+        assert result["click_behavior"]["targetId"] == 404
+        assert "No card mapping found for click_behavior targetId 404" in caplog.text
+
+    def test_click_behavior_unmapped_dashboard_kept(self, remapper, caplog):
+        settings = {"click_behavior": {"type": "link", "linkType": "dashboard", "targetId": 404}}
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            result = remapper.remap_dashcard_visualization_settings(settings, None)
+
+        assert result["click_behavior"]["targetId"] == 404
+        assert "No dashboard mapping found for click_behavior targetId 404" in caplog.text
+
+    def test_click_behavior_non_link_type_untouched(self, remapper):
+        settings = {"click_behavior": {"type": "crossfilter", "targetId": 5}}
+        result = remapper.remap_dashcard_visualization_settings(settings, None)
+        assert result["click_behavior"]["targetId"] == 5
+
+    def test_click_behavior_non_integer_target_untouched(self, remapper):
+        settings = {"click_behavior": {"type": "link", "linkType": "question", "targetId": "abc"}}
+        result = remapper.remap_dashcard_visualization_settings(settings, None)
+        assert result["click_behavior"]["targetId"] == "abc"
+
+    def test_click_behavior_non_dict_returned_as_is(self, remapper):
+        assert remapper._remap_click_behavior("not-a-dict") == "not-a-dict"
+
+    def test_column_settings_click_behavior_remapped(self, remapper):
+        settings = {
+            "column_settings": {
+                '["name","ID"]': {
+                    "click_behavior": {"type": "link", "linkType": "question", "targetId": 5}
+                },
+                '["name","Other"]': {"column_title": "Other"},
+            }
+        }
+
+        result = remapper.remap_dashcard_visualization_settings(settings, None)
+
+        assert result["column_settings"]['["name","ID"]']["click_behavior"]["targetId"] == 50
+        assert result["column_settings"]['["name","Other"]'] == {"column_title": "Other"}
+
+    def test_column_settings_non_dict_entry_ignored(self, remapper):
+        settings = {"column_settings": {"col": "not-a-dict"}}
+        result = remapper.remap_dashcard_visualization_settings(settings, None)
+        assert result["column_settings"]["col"] == "not-a-dict"
+
+    def test_column_settings_not_a_dict_ignored(self, remapper):
+        settings = {"column_settings": []}
+        result = remapper.remap_dashcard_visualization_settings(settings, None)
+        assert result["column_settings"] == []
+
+    def test_field_ids_remapped_when_source_db_given(self, remapper):
+        settings = {"graph.dimensions": [["field", 200, None]]}
+        result = remapper.remap_dashcard_visualization_settings(settings, 1)
+        assert result["graph.dimensions"] == [["field", 2000, None]]
+
+    def test_input_not_mutated(self, remapper):
+        settings = {"click_behavior": {"type": "link", "linkType": "question", "targetId": 5}}
+        remapper.remap_dashcard_visualization_settings(settings, None)
+        assert settings["click_behavior"]["targetId"] == 5
+
+
+class TestVisualizerSettings:
+    """Tests for the Visualizer columnValuesMapping remapping."""
+
+    def test_source_id_remapped(self, remapper):
+        settings = {
+            "visualization": {
+                "columnValuesMapping": {
+                    "COLUMN_1": [{"sourceId": "card:5", "name": "c", "originalName": "c"}]
+                }
+            }
+        }
+
+        result = remapper.remap_dashcard_visualization_settings(settings, None)
+
+        mapping = result["visualization"]["columnValuesMapping"]["COLUMN_1"]
+        assert mapping[0]["sourceId"] == "card:50"
+
+    def test_source_id_unmapped_kept(self, remapper, caplog):
+        settings = {"visualization": {"columnValuesMapping": {"C": [{"sourceId": "card:404"}]}}}
+
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            result = remapper.remap_dashcard_visualization_settings(settings, None)
+
+        assert result["visualization"]["columnValuesMapping"]["C"][0]["sourceId"] == "card:404"
+        assert "No card mapping found for Visualizer sourceId card:404" in caplog.text
+
+    def test_invalid_source_id_logged(self, remapper, caplog):
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            result = remapper._remap_visualizer_source_id({"sourceId": "card:abc"})
+
+        assert result["sourceId"] == "card:abc"
+        assert "Invalid Visualizer sourceId format: card:abc" in caplog.text
+
+    def test_non_card_source_id_untouched(self, remapper):
+        assert remapper._remap_visualizer_source_id({"sourceId": "table:5"}) == {
+            "sourceId": "table:5"
+        }
+
+    def test_non_string_source_id_untouched(self, remapper):
+        assert remapper._remap_visualizer_source_id({"sourceId": 5}) == {"sourceId": 5}
+
+    def test_data_source_name_reference_remapped(self, remapper):
+        settings = {"visualization": {"columnValuesMapping": {"C": ["$_card:5_name"]}}}
+
+        result = remapper.remap_dashcard_visualization_settings(settings, None)
+
+        assert result["visualization"]["columnValuesMapping"]["C"] == ["$_card:50_name"]
+
+    def test_data_source_name_reference_unmapped_kept(self, remapper, caplog):
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            result = remapper._remap_data_source_name_ref("$_card:404_name")
+
+        assert result == "$_card:404_name"
+        assert "No card mapping found for data source name ref" in caplog.text
+
+    def test_data_source_name_reference_bad_format_kept(self, remapper):
+        assert remapper._remap_data_source_name_ref("$_card:x_name") == "$_card:x_name"
+
+    def test_other_list_items_preserved(self, remapper):
+        settings = {"visualization": {"columnValuesMapping": {"C": [42, {"name": "no-source"}]}}}
+
+        result = remapper.remap_dashcard_visualization_settings(settings, None)
+
+        assert result["visualization"]["columnValuesMapping"]["C"] == [42, {"name": "no-source"}]
+
+    def test_non_list_mapping_values_preserved(self, remapper):
+        settings = {"visualization": {"columnValuesMapping": {"C": "scalar"}}}
+        result = remapper.remap_dashcard_visualization_settings(settings, None)
+        assert result["visualization"]["columnValuesMapping"]["C"] == "scalar"
+
+    def test_visualization_without_column_values_mapping(self, remapper):
+        settings = {"visualization": {"display": "bar"}}
+        result = remapper.remap_dashcard_visualization_settings(settings, None)
+        assert result["visualization"] == {"display": "bar"}
+
+    def test_visualization_not_a_dict_ignored(self, remapper):
+        settings = {"visualization": "bar"}
+        result = remapper.remap_dashcard_visualization_settings(settings, None)
+        assert result["visualization"] == "bar"
+
+    def test_remap_visualizer_definition_non_dict(self, remapper):
+        assert remapper._remap_visualizer_definition("nope") == "nope"
+
+
+class TestLinkCardSettings:
+    """Tests for _remap_link_card_settings."""
+
+    @pytest.mark.parametrize("model", ["card", "question", "model", "metric"])
+    def test_card_like_entities_remapped(self, remapper, model):
+        settings = {"link": {"entity": {"id": 5, "model": model}}}
+
+        result = remapper.remap_dashcard_visualization_settings(settings, None)
+
+        assert result["link"]["entity"]["id"] == 50
+
+    def test_dashboard_entity_remapped(self, remapper):
+        settings = {"link": {"entity": {"id": 7, "model": "dashboard"}}}
+
+        result = remapper.remap_dashcard_visualization_settings(settings, None)
+
+        assert result["link"]["entity"]["id"] == 70
+
+    def test_unmapped_card_entity_kept(self, remapper, caplog):
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            result = remapper._remap_link_card_settings({"entity": {"id": 404, "model": "card"}})
+
+        assert result["entity"]["id"] == 404
+        assert "No card mapping found for link card entity id 404" in caplog.text
+
+    def test_unmapped_dashboard_entity_kept(self, remapper, caplog):
+        with caplog.at_level("WARNING", logger="metabase_migration"):
+            result = remapper._remap_link_card_settings(
+                {"entity": {"id": 404, "model": "dashboard"}}
+            )
+
+        assert result["entity"]["id"] == 404
+        assert "No dashboard mapping found for link card entity id 404" in caplog.text
+
+    def test_restricted_entity_untouched(self, remapper):
+        link = {"entity": {"id": 5, "model": "card", "restricted": True}}
+        assert remapper._remap_link_card_settings(link)["entity"]["id"] == 5
+
+    def test_entity_not_a_dict_untouched(self, remapper):
+        link = {"entity": "nope"}
+        assert remapper._remap_link_card_settings(link) == link
+
+    def test_non_integer_entity_id_untouched(self, remapper):
+        link = {"entity": {"id": "abc", "model": "card"}}
+        assert remapper._remap_link_card_settings(link)["entity"]["id"] == "abc"
+
+    def test_unknown_model_untouched(self, remapper):
+        link = {"entity": {"id": 5, "model": "collection"}}
+        assert remapper._remap_link_card_settings(link)["entity"]["id"] == 5
+
+    def test_url_link_without_entity(self, remapper):
+        settings = {"link": {"url": "https://example.com"}}
+        result = remapper.remap_dashcard_visualization_settings(settings, None)
+        assert result["link"] == {"url": "https://example.com"}
+
+    def test_link_not_a_dict_ignored(self, remapper):
+        settings = {"link": "https://example.com"}
+        result = remapper.remap_dashcard_visualization_settings(settings, None)
+        assert result["link"] == "https://example.com"
+
+    def test_remap_link_card_settings_non_dict(self, remapper):
+        assert remapper._remap_link_card_settings("nope") == "nope"

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -272,6 +272,21 @@ class TestSyncConfigValidation:
 
         assert "positive" in str(exc_info.value).lower()
 
+    def test_negative_exclude_database_ids(self):
+        """Test that negative excluded database IDs are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            SyncConfig(
+                source_url="https://source.example.com",
+                source_session_token="token",
+                target_url="https://target.example.com",
+                target_session_token="token",
+                export_dir="./export",
+                db_map_path="./db_map.json",
+                exclude_database_ids=[4, -24],
+            )
+
+        assert "positive" in str(exc_info.value).lower()
+
 
 class TestSyncConfigConversion:
     """Test SyncConfig conversion to ExportConfig and ImportConfig."""
@@ -290,6 +305,7 @@ class TestSyncConfigConversion:
             include_archived=True,
             include_permissions=True,
             root_collection_ids=[1, 2, 3],
+            exclude_database_ids=[4, 24],
             log_level="DEBUG",
         )
 
@@ -303,6 +319,7 @@ class TestSyncConfigConversion:
         assert export_config.include_archived is True
         assert export_config.include_permissions is True
         assert export_config.root_collection_ids == [1, 2, 3]
+        assert export_config.exclude_database_ids == [4, 24]
         assert export_config.log_level == "DEBUG"
 
     def test_to_import_config(self):
@@ -419,6 +436,8 @@ class TestGetSyncArgs:
             "overwrite",
             "--root-collections",
             "24,25",
+            "--exclude-databases",
+            "4,39",
             "--log-level",
             "DEBUG",
         ],
@@ -442,6 +461,7 @@ class TestGetSyncArgs:
         assert config.apply_permissions is True
         assert config.conflict_strategy == "overwrite"
         assert config.root_collection_ids == [24, 25]
+        assert config.exclude_database_ids == [4, 39]
         assert config.log_level == "DEBUG"
 
     @patch.dict(


### PR DESCRIPTION
## Description

Raises unit test coverage from **86.81% to 97.76%** and bumps the enforced threshold
(`fail_under`) from 85% to 95% in both `pytest.ini` and `pyproject.toml`.

**No production code is changed** — this PR only adds tests and moves the coverage gate.

> ⚠️ **Stacks on #68.** `main` does not contain `--exclude-databases` yet, and a
> meaningful share of the new `export_service` / `config` tests exercise that flag,
> so this branch includes #68's commit (`38ebfac`) as its base. Merge #68 first and
> this diff reduces to the test commit alone — or merge this one and close #68 as
> superseded. Either works; the test commit is cleanly separated (`024d9fd`).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD improvement

## Related Issues

Builds on #68 (Fixes #67).

## Changes Made

Five new test modules, targeting the branches the existing suites never reached.
Each covers the warning/fallback/error paths rather than re-testing happy paths
already covered elsewhere.

| Module | Before | After | New tests |
|---|---|---|---|
| `lib/remapping/query_remapper.py` | 64.79% | **99.86%** | `tests/test_query_remapper.py` (134) |
| `lib/services/export_service.py` | 74.53% | **99.59%** | `tests/test_export_service_internals.py` (84) |
| `lib/remapping/id_mapper.py` | 85.31% | **100%** | `tests/test_id_mapper.py` (24) |
| `lib/config.py` | 89.43% | **98.73%** | `tests/test_config_cli_errors.py` (32) |
| `lib/client.py` | 93.78% | **99.48%** | `tests/test_misc_coverage_gaps.py` (35) |
| `lib/models_core.py`, `lib/utils/file_io.py`, `lib/utils/query.py` | 88–95% | **100%** | ″ |

What the new tests actually cover:

- **`test_query_remapper.py`** — unmapped-ID warning branches for tables, fields, cards
  and dashboards; malformed MBQL (`card__abc`, non-dict stages, non-list `stages`);
  v57 joins with nested stages; `["metric", {…}, card_id]` aggregation refs; template-tag
  renaming (`#5-orders` → `#50-orders`, incl. `display-name`) and `temporal-unit` tags;
  Visualizer `columnValuesMapping` (`card:123` and `$_card:123_name`); `click_behavior`
  question/dashboard targets and column-level click behaviors; link-card entities.
- **`test_export_service_internals.py`** — `MetabaseAPIError` and unexpected-exception
  paths in `run_export`, `_export_card`, `_export_dashboard` and `_export_permissions`;
  circular dependency detection (incl. a genuine mutual A↔B reference); dependencies
  landing in the `dependencies/` folder when out of scope; archived-card export via
  `/api/card?f=archived`; the 404-archived-dashboard skip vs. re-raise; and the
  `--exclude-databases` skip both before dependency traversal and in `_export_card`.
- **`test_id_mapper.py`** — `by_id` precedence over `by_name`, name-based fallback,
  and `build_table_and_field_mappings` with unmapped databases, absent source metadata,
  fetch failures, target-metadata caching, and tables/fields missing on the target.
- **`test_config_cli_errors.py`** — every `parser.error()` branch across
  `get_export_args` / `get_import_args` / `get_sync_args`: missing URLs, unsupported
  `MB_METABASE_VERSION`, malformed `--root-collections` / `--exclude-databases`, and both
  the `ConfigValidationError` and generic-exception branches around config construction.
  Each test neutralises `python-dotenv` so the repo's own `.env` cannot leak in.
- **`test_misc_coverage_gaps.py`** — client HTTP-error logging (JSON pretty-print vs. raw
  text fallback, request-body logging) and multi-page pagination; `CustomJsonEncoder` for
  Pydantic models, dataclasses and sets; `ImportReport`'s `items`/`results` aliasing.

## Testing

### Test Configuration

- Python version: 3.13.7
- Operating System: macOS (Darwin 24.3)
- Metabase version (if applicable): N/A (unit tests with mocked API client)

### Test Results

- [x] All existing tests pass
- [x] New tests added and passing
- [ ] Manual testing completed

`1072 passed, 3 skipped` (up from 763), coverage **97.76%** against the new 95% gate.
No test touches the network; the Metabase client is mocked throughout.

### Test Commands Run

```bash
pytest tests/ -m "not integration"   # 1072 passed, 3 skipped, coverage 97.76%
black --check lib/ tests/ *.py       # 66 files unchanged
ruff check lib/ tests/ *.py          # All checks passed
isort --check-only tests/test_*.py   # new files clean
mypy lib/ --ignore-missing-imports   # Success: no issues found in 26 source files
```

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have updated the CHANGELOG.md file
- [x] I have checked my code with black, ruff, and mypy

## Breaking Changes

None for library consumers. **CI note:** the coverage gate moves from 85% to 95%, so any
future PR that drops coverage below 95% will now fail rather than pass.

## Migration Guide

N/A

## Additional Notes

Remaining uncovered lines are concentrated in `lib/handlers/dashboard.py` (91.82%),
`lib/handlers/card.py` (94.12%) and `lib/services/import_service.py` (94.33%). Those
paths need a fuller import-side fixture setup than this PR takes on; they can be raised
in a follow-up if you want the gate higher than 95%.

Two intentionally-unreachable lines were left alone rather than tested around:
`lib/config.py`'s `raise  # Unreachable: parser.error() raises SystemExit` statements,
and `lib/version.py:701` (a defensive raise after every `MetabaseVersion` enum member is
already handled).

## Code Quality

```bash
# Run these commands before submitting:
black lib/ tests/ *.py
ruff check lib/ tests/ *.py
mypy lib/
pytest --cov=lib
```

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the MIT License.**
