### PR TITLE
fix: Remap field IDs in list-form template-tags on import for Metabase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Temporal-unit template-tag field remapping**: Time-grouping variables (e.g. `date_grouping`)
   use template-tag type `temporal-unit` and were left with staging field IDs while `dimension`
   tags remapped correctly. Field IDs in `temporal-unit` tags are now remapped as well.
+- **List-form template-tags field remapping**: Metabase v0.63+ exports `template-tags` as a list
+  of tag objects rather than a name-keyed dict (PR
+  [metabase#77133](https://github.com/metabase/metabase/pull/77133)). Import only remapped the
+  dict shape, so field filters such as `date_range` (`dbo.DimDate.Date`) kept source field IDs
+  and resolved to unrelated fields on the target (e.g. `MonthDate`). List-form tags are now
+  remapped the same way as dict-form tags.
 
 ## [1.2.0] - 2026-03-20
 

--- a/lib/handlers/card.py
+++ b/lib/handlers/card.py
@@ -24,7 +24,11 @@ from lib.constants import (
 from lib.handlers.base import _CARD_TYPE_TO_MODEL, BaseHandler, ImportContext
 from lib.models import Card
 from lib.utils import clean_for_create, read_json_file
-from lib.utils.query import extract_metric_deps_from_clause, extract_parameter_card_dependencies
+from lib.utils.query import (
+    extract_metric_deps_from_clause,
+    extract_parameter_card_dependencies,
+    iter_template_tags,
+)
 
 logger = logging.getLogger("metabase_migration")
 
@@ -451,18 +455,19 @@ class CardHandler(BaseHandler):
                 logger.warning(f"Invalid card ID in SQL reference: {card_id_str}")
 
     @staticmethod
-    def _extract_template_tag_deps(template_tags: dict[str, Any], dependencies: set[int]) -> None:
+    def _extract_template_tag_deps(
+        template_tags: dict[str, Any] | list[Any], dependencies: set[int]
+    ) -> None:
         """Extracts card IDs from template-tags with type "card".
 
+        Supports both dict (keyed by name) and list (v0.63+ export) forms.
+
         Args:
-            template_tags: The template-tags dictionary.
+            template_tags: The template-tags dictionary or list.
             dependencies: Set to add found card IDs to.
         """
-        if not isinstance(template_tags, dict):
-            return
-
-        for _tag_name, tag_data in template_tags.items():
-            if isinstance(tag_data, dict) and tag_data.get("type") == "card":
+        for _tag_name, tag_data in iter_template_tags(template_tags):
+            if tag_data.get("type") == "card":
                 card_id = tag_data.get("card-id")
                 if card_id is not None:
                     dependencies.add(card_id)

--- a/lib/remapping/query_remapper.py
+++ b/lib/remapping/query_remapper.py
@@ -660,9 +660,9 @@ class QueryRemapper:
         if isinstance(query_str, str):
             native["query"] = self._remap_sql_card_references(query_str)
 
-        # Remap template-tags
+        # Remap template-tags (dict or list form)
         template_tags = native.get(TEMPLATE_TAGS_KEY)
-        if isinstance(template_tags, dict):
+        if isinstance(template_tags, dict | list):
             native[TEMPLATE_TAGS_KEY] = self._remap_template_tags(template_tags, source_db_id)
 
     def _remap_native_query_v57(self, dataset_query: dict[str, Any], source_db_id: int) -> None:
@@ -678,6 +678,8 @@ class QueryRemapper:
                     "template-tags": {
                         "123-model": {"type": "card", "card-id": 123, ...}
                     }
+                    # or, in v0.63+ exports, a list of tag objects:
+                    # "template-tags": [{"name": "date_range", "type": "dimension", ...}]
                 }
             ]
         }
@@ -699,9 +701,9 @@ class QueryRemapper:
             if isinstance(native_sql, str):
                 stage[NATIVE_KEY] = self._remap_sql_card_references(native_sql)
 
-            # Remap template-tags at stage level
+            # Remap template-tags at stage level (dict or list form)
             template_tags = stage.get(TEMPLATE_TAGS_KEY)
-            if isinstance(template_tags, dict):
+            if isinstance(template_tags, dict | list):
                 stage[TEMPLATE_TAGS_KEY] = self._remap_template_tags(template_tags, source_db_id)
 
     def _remap_sql_card_references(self, sql: str) -> str:
@@ -737,20 +739,43 @@ class QueryRemapper:
         return re.sub(NATIVE_CARD_REF_FULL_PATTERN, replace_card_ref, sql)
 
     def _remap_template_tags(
-        self, template_tags: dict[str, Any], source_db_id: int = 0
-    ) -> dict[str, Any]:
+        self, template_tags: dict[str, Any] | list[Any], source_db_id: int = 0
+    ) -> dict[str, Any] | list[Any]:
         """Remaps card and dimension references in template-tags.
 
         Updates both the tag names and the card-id values for card-type tags,
         and remaps field IDs in dimension-type and temporal-unit tags.
 
+        Accepts both dict (legacy / keyed-by-name) and list (v0.63+ export) forms
+        and returns the same container type.
+
         Args:
-            template_tags: The template-tags dictionary.
+            template_tags: The template-tags dictionary or list.
             source_db_id: The source database ID for field lookups.
 
         Returns:
-            A new dictionary with remapped template tags.
+            Remapped template tags in the same container type as the input.
         """
+        if isinstance(template_tags, list):
+            remapped_list: list[Any] = []
+            for tag_data in template_tags:
+                if not isinstance(tag_data, dict):
+                    remapped_list.append(tag_data)
+                    continue
+                tag_name = str(tag_data.get("name") or "")
+                remapped_as_dict = self._remap_template_tags_dict(
+                    {tag_name: tag_data}, source_db_id
+                )
+                # Card tags may change their key/name; take the remapped value.
+                remapped_list.append(next(iter(remapped_as_dict.values())))
+            return remapped_list
+
+        return self._remap_template_tags_dict(template_tags, source_db_id)
+
+    def _remap_template_tags_dict(
+        self, template_tags: dict[str, Any], source_db_id: int = 0
+    ) -> dict[str, Any]:
+        """Remaps template-tags stored as a name-keyed dictionary."""
         remapped_tags: dict[str, Any] = {}
 
         for tag_name, tag_data in template_tags.items():

--- a/lib/utils/query.py
+++ b/lib/utils/query.py
@@ -1,6 +1,28 @@
 """Helpers for extracting card dependencies from Metabase query structures."""
 
+from collections.abc import Iterator
 from typing import Any
+
+
+def iter_template_tags(
+    template_tags: Any,
+) -> Iterator[tuple[str, dict[str, Any]]]:
+    """Yield (name, tag_data) pairs from dict or list template-tags.
+
+    Metabase historically stores template-tags as a dict keyed by name.
+    From v0.63 onward (metabase#77133) they are serialized as a list of
+    tag objects, each with a ``name`` field. Both shapes are accepted.
+    """
+    if isinstance(template_tags, dict):
+        for tag_name, tag_data in template_tags.items():
+            if isinstance(tag_data, dict):
+                yield str(tag_name), tag_data
+        return
+
+    if isinstance(template_tags, list):
+        for tag_data in template_tags:
+            if isinstance(tag_data, dict):
+                yield str(tag_data.get("name") or ""), tag_data
 
 
 def extract_parameter_card_dependencies(card_data: dict[str, Any]) -> set[int]:

--- a/lib/version.py
+++ b/lib/version.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from lib.constants import MetabaseVersion
+from lib.utils.query import iter_template_tags
 
 logger = logging.getLogger("metabase_migration")
 
@@ -450,10 +451,10 @@ class V57Adapter(VersionAdapter):
 
                 # Check template-tags for native stages (card references)
                 template_tags = stage.get(self.mbql.template_tags_key, {})
-                for _tag_name, tag_data in template_tags.items():
-                    if isinstance(tag_data, dict) and tag_data.get("type") == "card":
+                for _tag_name, tag_data in iter_template_tags(template_tags):
+                    if tag_data.get("type") == "card":
                         card_id_value = tag_data.get("card-id")
-                        if card_id_value is not None and isinstance(card_id_value, int):
+                        if isinstance(card_id_value, int):
                             dependencies.add(card_id_value)
         else:
             # Fallback to v56-style query structure
@@ -483,10 +484,10 @@ class V57Adapter(VersionAdapter):
             native = dataset_query.get(self.mbql.native_query_key, {})
             if isinstance(native, dict):
                 template_tags = native.get(self.mbql.template_tags_key, {})
-                for _tag_name, tag_data in template_tags.items():
-                    if isinstance(tag_data, dict) and tag_data.get("type") == "card":
+                for _tag_name, tag_data in iter_template_tags(template_tags):
+                    if tag_data.get("type") == "card":
                         card_id_value = tag_data.get("card-id")
-                        if card_id_value is not None and isinstance(card_id_value, int):
+                        if isinstance(card_id_value, int):
                             dependencies.add(card_id_value)
 
         return dependencies
@@ -587,8 +588,8 @@ class V58Adapter(VersionAdapter):
                             logger.warning(f"Invalid card reference in join: {join_source}")
 
                 template_tags = stage.get(self.mbql.template_tags_key, {})
-                for _tag_name, tag_data in template_tags.items():
-                    if isinstance(tag_data, dict) and tag_data.get("type") == "card":
+                for _tag_name, tag_data in iter_template_tags(template_tags):
+                    if tag_data.get("type") == "card":
                         card_id_value = tag_data.get("card-id")
                         if isinstance(card_id_value, int):
                             dependencies.add(card_id_value)
@@ -615,8 +616,8 @@ class V58Adapter(VersionAdapter):
             native = dataset_query.get(self.mbql.native_query_key, {})
             if isinstance(native, dict):
                 template_tags = native.get(self.mbql.template_tags_key, {})
-                for _tag_name, tag_data in template_tags.items():
-                    if isinstance(tag_data, dict) and tag_data.get("type") == "card":
+                for _tag_name, tag_data in iter_template_tags(template_tags):
+                    if tag_data.get("type") == "card":
                         card_id_value = tag_data.get("card-id")
                         if isinstance(card_id_value, int):
                             dependencies.add(card_id_value)

--- a/tests/test_card_handler.py
+++ b/tests/test_card_handler.py
@@ -305,6 +305,35 @@ class TestExtractCardDependencies:
         deps = CardHandler._extract_card_dependencies(card_data)
         assert deps == set()
 
+    def test_extract_list_form_template_tags(self):
+        """v0.63+ list-form template-tags must still yield card dependencies."""
+        card_data = {
+            "dataset_query": {
+                "lib/type": "mbql/query",
+                "database": 1,
+                "stages": [
+                    {
+                        "lib/type": "mbql.stage/native",
+                        "native": "SELECT * FROM {{#50-my-model}}",
+                        "template-tags": [
+                            {
+                                "type": "card",
+                                "name": "50-my-model",
+                                "card-id": 50,
+                            },
+                            {
+                                "type": "dimension",
+                                "name": "date_range",
+                                "dimension": ["field", {"lib/uuid": "x"}, 159],
+                            },
+                        ],
+                    }
+                ],
+            }
+        }
+        deps = CardHandler._extract_card_dependencies(card_data)
+        assert deps == {50}
+
 
 class TestFindExistingCard:
     """Tests for finding existing cards via ImportContext."""

--- a/tests/test_card_parameter_remapping.py
+++ b/tests/test_card_parameter_remapping.py
@@ -192,3 +192,94 @@ class TestTemporalUnitTemplateTagRemapping:
             "date_grouping"
         ]["dimension"]
         assert tag_dimension[2] == 301
+
+    def test_remap_card_data_remaps_list_form_date_range_dimension(self):
+        """v0.63+ exports template-tags as a list; date_range field IDs must remap.
+
+        Without this, source DimDate.Date (field 159) keeps its staging ID and
+        resolves to an unrelated target field (e.g. MonthDate).
+        """
+        id_mapper = _create_test_id_mapper(db_mapping={2: 2})
+        id_mapper._field_map[(2, 159)] = 301
+
+        remapper = QueryRemapper(id_mapper)
+        card_data = {
+            "database_id": 2,
+            "dataset_query": {
+                "lib/type": "mbql/query",
+                "database": 2,
+                "stages": [
+                    {
+                        "lib/type": "mbql.stage/native",
+                        "native": "SELECT 1 WHERE {{date_range}}",
+                        "template-tags": [
+                            {
+                                "widget-type": "date/all-options",
+                                "default": "past7days",
+                                "name": "date_range",
+                                "type": "dimension",
+                                "id": "213629bc-f979-4e6e-a2e1-5670baf79855",
+                                "dimension": [
+                                    "field",
+                                    {"lib/uuid": "1156aab8-566e-45d0-8e19-cd181d67590c"},
+                                    159,
+                                ],
+                                "display-name": "Date Range",
+                                "required": True,
+                            },
+                            {
+                                "name": "client",
+                                "type": "text",
+                                "id": "a9de63f6-4ea2-496c-84a7-098ca0769b91",
+                                "display-name": "Client",
+                            },
+                        ],
+                    }
+                ],
+            },
+        }
+
+        remapped_data, success = remapper.remap_card_data(card_data)
+
+        assert success is True
+        tags = remapped_data["dataset_query"]["stages"][0]["template-tags"]
+        assert isinstance(tags, list)
+        date_range = next(tag for tag in tags if tag["name"] == "date_range")
+        assert date_range["dimension"][2] == 301
+        # Non-dimension tags stay in the list unchanged
+        assert any(tag.get("name") == "client" for tag in tags)
+
+    def test_remap_card_data_remaps_list_form_temporal_unit_tag(self):
+        id_mapper = _create_test_id_mapper(db_mapping={2: 2})
+        id_mapper._field_map[(2, 159)] = 301
+
+        remapper = QueryRemapper(id_mapper)
+        card_data = {
+            "database_id": 2,
+            "dataset_query": {
+                "lib/type": "mbql/query",
+                "database": 2,
+                "stages": [
+                    {
+                        "lib/type": "mbql.stage/native",
+                        "native": 'SELECT {{date_grouping}} AS "Date"',
+                        "template-tags": [
+                            {
+                                "type": "temporal-unit",
+                                "name": "date_grouping",
+                                "display-name": "Date Grouping",
+                                "default": "day",
+                                "dimension": ["field", {"lib/uuid": "abc"}, 159],
+                            }
+                        ],
+                    }
+                ],
+            },
+        }
+
+        remapped_data, success = remapper.remap_card_data(card_data)
+
+        assert success is True
+        tags = remapped_data["dataset_query"]["stages"][0]["template-tags"]
+        assert isinstance(tags, list)
+        assert tags[0]["dimension"][2] == 301

--- a/tests/test_native_query_remapping.py
+++ b/tests/test_native_query_remapping.py
@@ -1156,6 +1156,79 @@ class TestDimensionTemplateTagRemapping:
         # Unmapped field should be preserved with original ID
         assert tag["dimension"][2] == 99999
 
+    def test_remap_v57_list_form_dimension_template_tags(self, remapper):
+        """v0.63+ exports template-tags as a list; field IDs must still remap."""
+        remapper.id_mapper._field_map[(1, 3000)] = 9000
+        card_data = {
+            "database_id": 1,
+            "dataset_query": {
+                "lib/type": "mbql/query",
+                "database": 1,
+                "stages": [
+                    {
+                        "lib/type": "mbql.stage/native",
+                        "native": "SELECT * FROM venues WHERE {{venue_type_label}}",
+                        "template-tags": [
+                            {
+                                "type": "dimension",
+                                "name": "venue_type_label",
+                                "id": "abc-123",
+                                "display-name": "Venue Type Label",
+                                "widget-type": "string/=",
+                                "dimension": [
+                                    "field",
+                                    {
+                                        "base-type": "type/Text",
+                                        "lib/uuid": "550e8400-e29b-41d4-a716-446655440000",
+                                    },
+                                    3000,
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        }
+
+        result, success = remapper.remap_card_data(card_data)
+
+        assert success
+        tags = result["dataset_query"]["stages"][0]["template-tags"]
+        assert isinstance(tags, list)
+        assert tags[0]["dimension"][2] == 9000
+
+    def test_remap_list_form_card_template_tag(self, remapper):
+        """List-form card template-tags must remap card-id and name."""
+        card_data = {
+            "database_id": 1,
+            "dataset_query": {
+                "lib/type": "mbql/query",
+                "database": 1,
+                "stages": [
+                    {
+                        "lib/type": "mbql.stage/native",
+                        "native": "SELECT * FROM {{#50-my-model}}",
+                        "template-tags": [
+                            {
+                                "type": "card",
+                                "name": "50-my-model",
+                                "display-name": "#50 My Model",
+                                "card-id": 50,
+                            }
+                        ],
+                    }
+                ],
+            },
+        }
+
+        result, success = remapper.remap_card_data(card_data)
+
+        assert success
+        tags = result["dataset_query"]["stages"][0]["template-tags"]
+        assert isinstance(tags, list)
+        assert tags[0]["card-id"] == 500
+        assert tags[0]["name"] == "500-my-model"
+
 
 class TestQueryRemapperEdgeCases:
     """Tests for edge cases in query remapping."""

--- a/tests/test_utils_query.py
+++ b/tests/test_utils_query.py
@@ -1,10 +1,38 @@
 """
 Unit tests for lib/utils/query.py
 
-Tests for extract_metric_deps_from_clause.
+Tests for extract_metric_deps_from_clause and iter_template_tags.
 """
 
-from lib.utils.query import extract_metric_deps_from_clause
+from lib.utils.query import extract_metric_deps_from_clause, iter_template_tags
+
+
+class TestIterTemplateTags:
+    """Tests for iter_template_tags supporting dict and list forms."""
+
+    def test_dict_form(self):
+        tags = {
+            "date_range": {"type": "dimension", "name": "date_range"},
+            "client": {"type": "text", "name": "client"},
+        }
+        assert list(iter_template_tags(tags)) == [
+            ("date_range", tags["date_range"]),
+            ("client", tags["client"]),
+        ]
+
+    def test_list_form(self):
+        tags = [
+            {"type": "dimension", "name": "date_range"},
+            {"type": "text", "name": "client"},
+        ]
+        assert list(iter_template_tags(tags)) == [
+            ("date_range", tags[0]),
+            ("client", tags[1]),
+        ]
+
+    def test_invalid_returns_empty(self):
+        assert list(iter_template_tags("invalid")) == []
+        assert list(iter_template_tags(None)) == []
 
 
 class TestExtractMetricDepsFromClause:


### PR DESCRIPTION
### Soft support for matabase v0.63+

Metabase v0.63+ exports template-tags as a list; only the dict shape was remapped, so date_range field filters kept source IDs and resolved to unrelated target fields.

# Pull Request

## Description

Remap field IDs in list-form template-tags on import so Metabase v0.63+ field filters (e.g. date_range) keep the correct target field instead of resolving by raw source ID.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD improvement

## Related Issues

Fixes #
Relates to #

## Changes Made

- Remap field IDs in list-form template-tags on import (Metabase v0.63+ map→list shape)
- Preserve container type: dict in → dict out, list in → list out
- Remap dimension and temporal-unit field refs in list-form tags (fixes date_range / date_grouping)
- Remap card-type tags in list form (card-id / name)
- Shared iter_template_tags() helper for dict and list shapes
- Dependency extraction updated for list-form tags (card handler + v57/v58 adapters)
- Unit tests for list-form remapping, deps extraction, and iter_template_tags

## Testing

`make test`

### Test Configuration

- Python version:
- Operating System:
- Metabase version (if applicable):

### Test Results

- [x] All existing tests pass
- [x] New tests added and passing
- [x] Manual testing completed

### Test Commands Run

```bash
# Example:
pytest tests/
pytest --cov=lib --cov-report=term-missing
```

## Screenshots (if applicable)
N/A


## Checklist


- [x] My code follows the project's style guidelines
- [x} I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have updated the CHANGELOG.md file
- [x] I have checked my code with black, ruff, and mypy

## Breaking Changes

No. Dict-form tags still work; list-form is additive. Import behavior for v0.63+ field filters is corrected, not changed for older map-shaped exports.

## Migration Guide

N/A

## Additional Notes

Metabase changed :template-tags from a map to a list in [metabase#77133](https://github.com/metabase/metabase/pull/77133), shipped in v0.63 (backport [metabase#77652](https://github.com/metabase/metabase/pull/77652) onto release-x.63.x; v0.63.1).

## Code Quality

<!-- Confirm code quality checks -->

```bash
# Run these commands before submitting:
black lib/ tests/ *.py
ruff check lib/ tests/ *.py
mypy lib/
pytest --cov=lib
```

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the MIT License.**
