### PR TITLE
feat: full Metabase v63 support — fixes for all confirmed audit gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Metabase v63 support**: New `v63` version option with a dedicated adapter (same MBQL 5
+  stages format as v58). Versions v0.59–v0.62 remain unvalidated.
+- **Measure migration (v63)**: Measures (Data Studio saved aggregations) are exported into the
+  manifest, recreated on the target with remapped table and field IDs (matched by table + name
+  for idempotency), and `["measure", {...}, id]` aggregation references in card queries are
+  remapped.
+- **`--include-library` export flag (v63)**: Includes the Library (Data Studio) collection
+  subtree, which Metabase v63 excludes from the collection tree by default.
+- **Document detection (v63)**: Documents found in collections are counted and reported with a
+  warning during export (document migration itself is not yet supported).
+
 ### Fixed
+
+- **"table" template-tag remapping (v63)**: Table Variables store a raw source table ID
+  (`table-id`) and filter field IDs (`source-filters[].field-id`); both are now remapped on
+  import instead of being copied verbatim and resolving to the wrong table on the target.
+- **Parameter `label_field` remapping (v63)**: Filters sourcing dropdown values from another
+  card can specify a separate label column; `values_source_config.label_field` is now remapped
+  alongside `value_field`.
+- **Dashcard `inline_parameters` preserved (v63)**: Header- and card-level filter-widget
+  placement is no longer dropped when dashcards are rebuilt on import.
+- **Collection permission revocations propagated**: Metabase 0.56.13+ omits "none" entries from
+  the collection permissions graph, and PUT only overwrites pairs present in the request. The
+  importer now sends explicit "none" for mapped group/collection pairs absent from the source
+  graph, so source-side revocations no longer become inherited access on the target
+  (Administrators excluded; the "root" collection is never synthesized).
 
 - **Card parameter value source remapping**: Card filters that source dropdown values from
   another card (`parameters[].values_source_config.card_id`) kept staging card IDs on import,

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ The toolkit supports the following Metabase versions:
 | `v56`   | v0.56.x          | MBQL 4              | Default, fully supported |
 | `v57`   | v0.57.x          | MBQL 5 (stages)     | Fully supported          |
 | `v58`   | v0.58.x          | MBQL 5 (stages)     | Fully supported          |
+| `v63`   | v0.63.x          | MBQL 5 (stages)     | Supported (see notes)    |
+
+Versions v0.59–v0.62 have no dedicated support and have not been validated.
 
 ### Key Differences Between Versions
 
@@ -70,6 +73,21 @@ The toolkit supports the following Metabase versions:
 - Same query format as v57 (`:stages` array)
 - Card fields `dashboard_tab_id`, `entity_id`, `parameter_mappings` are now nullable
 - New MBQL clauses: `measure` (aggregation reference) and `collate` (SQL collation)
+
+**v63 (MBQL 5):**
+
+- Same query format as v58 (`:stages` array)
+- `template-tags` may be exported as a list of tag objects instead of a name-keyed dict
+- New `table` template-tag type (Table Variables); `table-id` and `source-filters` field IDs
+  are remapped on import
+- Measures (Data Studio saved aggregations) are exported and recreated on the target, and
+  `measure` aggregation references in card queries are remapped
+- Documents are detected and reported during export but are **not** migrated
+- The Library (Data Studio) subtree is excluded from the collection tree by Metabase unless
+  the export is run with `--include-library`
+- Filters can source dropdown labels from a separate column (`label_field`), and filter
+  widgets can be placed at dashboard, header, or card level (`inline_parameters`) — both are
+  migrated
 
 ### Version Compatibility
 
@@ -213,6 +231,7 @@ metabase-export \
 - `--include-dashboards` - Include dashboards in export
 - `--include-archived` - Include archived items
 - `--include-permissions` - Include permissions (groups and access control) in export
+- `--include-library` - Include the Library (Data Studio) collection subtree (v63 only)
 - `--root-collections` - Comma-separated collection IDs to export (optional)
 - `--log-level` - Logging level: DEBUG, INFO, WARNING, ERROR
 
@@ -329,6 +348,7 @@ metabase-sync \
 - `--include-dashboards` - Include dashboards in the export
 - `--include-archived` - Include archived items
 - `--include-permissions` - Include permissions (groups and access control)
+- `--include-library` - Include the Library (Data Studio) collection subtree (v63 only)
 - `--root-collections` - Comma-separated list of root collection IDs to export
 
 *Import Options:*

--- a/docker-compose.test.v63.yml
+++ b/docker-compose.test.v63.yml
@@ -1,0 +1,136 @@
+# Docker Compose for testing with Metabase v63 (MBQL 5 format, list-form template-tags, measures)
+# Use with: MB_METABASE_VERSION=v63 docker compose -f docker-compose.test.v63.yml up -d
+services:
+  # PostgreSQL database for source Metabase
+  source-postgres:
+    image: postgres:15-alpine
+    container_name: metabase-source-postgres-v63
+    environment:
+      POSTGRES_DB: metabase_source
+      POSTGRES_USER: metabase
+      POSTGRES_PASSWORD: metabase_password # pragma: allowlist-secret
+    ports:
+      - "5435:5432"
+    volumes:
+      - source-postgres-data-v63:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U metabase"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - metabase-test-network-v63
+
+  # PostgreSQL database for target Metabase
+  target-postgres:
+    image: postgres:15-alpine
+    container_name: metabase-target-postgres-v63
+    environment:
+      POSTGRES_DB: metabase_target
+      POSTGRES_USER: metabase
+      POSTGRES_PASSWORD: metabase_password # pragma: allowlist-secret
+    ports:
+      - "5433:5432"
+    volumes:
+      - target-postgres-data-v63:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U metabase"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - metabase-test-network-v63
+
+  # Sample data database (shared between source and target)
+  sample-data-postgres:
+    image: postgres:15-alpine
+    container_name: metabase-sample-data-v63
+    environment:
+      POSTGRES_DB: sample_data
+      POSTGRES_USER: sample_user
+      POSTGRES_PASSWORD: sample_password # pragma: allowlist-secret
+    ports:
+      - "5434:5432"
+    volumes:
+      - sample-data-v63:/var/lib/postgresql/data
+      - ./tests/integration/fixtures/init-sample-data.sql:/docker-entrypoint-initdb.d/init.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U sample_user"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - metabase-test-network-v63
+
+  # Source Metabase instance (v63)
+  source-metabase:
+    image: metabase/metabase:v0.63.14
+    container_name: metabase-source-v63
+    environment:
+      MB_DB_TYPE: postgres
+      MB_DB_DBNAME: metabase_source
+      MB_DB_PORT: 5432
+      MB_DB_USER: metabase
+      MB_DB_PASS: metabase_password # pragma: allowlist-secret
+      MB_DB_HOST: source-postgres
+      MB_JETTY_PORT: 3000
+      JAVA_TIMEZONE: UTC
+    ports:
+      - "3002:3000"
+    depends_on:
+      source-postgres:
+        condition: service_healthy
+      sample-data-postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 120s
+    networks:
+      - metabase-test-network-v63
+    volumes:
+      - source-metabase-data-v63:/metabase-data
+
+  # Target Metabase instance (v63)
+  target-metabase:
+    image: metabase/metabase:v0.63.14
+    container_name: metabase-target-v63
+    environment:
+      MB_DB_TYPE: postgres
+      MB_DB_DBNAME: metabase_target
+      MB_DB_PORT: 5432
+      MB_DB_USER: metabase
+      MB_DB_PASS: metabase_password # pragma: allowlist-secret
+      MB_DB_HOST: target-postgres
+      MB_JETTY_PORT: 3000
+      JAVA_TIMEZONE: UTC
+    ports:
+      - "3003:3000"
+    depends_on:
+      target-postgres:
+        condition: service_healthy
+      sample-data-postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 120s
+    networks:
+      - metabase-test-network-v63
+    volumes:
+      - target-metabase-data-v63:/metabase-data
+
+networks:
+  metabase-test-network-v63:
+    driver: bridge
+
+volumes:
+  source-postgres-data-v63:
+  target-postgres-data-v63:
+  sample-data-v63:
+  source-metabase-data-v63:
+  target-metabase-data-v63:

--- a/lib/client.py
+++ b/lib/client.py
@@ -274,6 +274,22 @@ class MetabaseClient:
         # The main PUT endpoint handles dashcard and tab updates
         return self._request("put", f"/dashboard/{dashboard_id}", json=payload).json()
 
+    # --- Measure API Methods (v63) ---
+
+    def get_measures(self) -> list[dict]:
+        """Fetches all measures (v63 Data Studio saved aggregations)."""
+        response = self._request("get", "/measure").json()
+        if isinstance(response, dict) and "data" in response:
+            data: list[dict] = response["data"]
+            return data
+        if isinstance(response, list):
+            return response
+        return []
+
+    def create_measure(self, payload: dict) -> Any:
+        """Creates a new measure (v63)."""
+        return self._request("post", "/measure", json=payload).json()
+
     # --- Permissions API Methods ---
 
     def get_permission_groups(self) -> Any:

--- a/lib/config.py
+++ b/lib/config.py
@@ -144,6 +144,7 @@ class ExportConfig(BaseModel):
     include_dashboards: bool = False
     include_archived: bool = False
     include_permissions: bool = False
+    include_library: bool = False
     root_collection_ids: list[int] | None = None
     log_level: str = "INFO"
 
@@ -331,6 +332,11 @@ def get_export_args() -> ExportConfig:
         help="Include permissions (groups and access control) in the export",
     )
     parser.add_argument(
+        "--include-library",
+        action="store_true",
+        help="Include the Library (Data Studio) collection subtree in the export (v63 only)",
+    )
+    parser.add_argument(
         "--root-collections",
         help="Comma-separated list of root collection IDs to export (empty=all)",
     )
@@ -379,6 +385,7 @@ def get_export_args() -> ExportConfig:
             include_dashboards=args.include_dashboards,
             include_archived=args.include_archived,
             include_permissions=args.include_permissions,
+            include_library=args.include_library,
             root_collection_ids=root_collection_ids,
             log_level=args.log_level,
         )
@@ -526,6 +533,7 @@ class SyncConfig(BaseModel):
     include_dashboards: bool = False
     include_archived: bool = False
     include_permissions: bool = False
+    include_library: bool = False
     root_collection_ids: list[int] | None = None
 
     # Import options
@@ -642,6 +650,7 @@ class SyncConfig(BaseModel):
             include_dashboards=self.include_dashboards,
             include_archived=self.include_archived,
             include_permissions=self.include_permissions,
+            include_library=self.include_library,
             root_collection_ids=self.root_collection_ids,
             log_level=self.log_level,
         )
@@ -750,6 +759,11 @@ def get_sync_args() -> SyncConfig:
         help="Include permissions (groups and access control)",
     )
     export_group.add_argument(
+        "--include-library",
+        action="store_true",
+        help="Include the Library (Data Studio) collection subtree in the export (v63 only)",
+    )
+    export_group.add_argument(
         "--root-collections",
         help="Comma-separated list of root collection IDs to export (empty=all)",
     )
@@ -819,6 +833,7 @@ def get_sync_args() -> SyncConfig:
             include_dashboards=args.include_dashboards,
             include_archived=args.include_archived,
             include_permissions=args.include_permissions,
+            include_library=args.include_library,
             root_collection_ids=root_collection_ids,
             conflict_strategy=args.conflict,
             dry_run=args.dry_run,

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -25,11 +25,14 @@ class MetabaseVersion(str, Enum):
     - V56: Legacy MBQL 4 format with `:type` field, `:native.query` structure
     - V57: MBQL 5 format with `:lib/type`, `:stages` array structure
     - V58: MBQL 5 format (same as V57) with nullable card fields (dashboard_tab_id, entity_id, parameter_mappings)
+    - V63: MBQL 5 format (same as V58) with list-form template-tags, "table" template tags,
+      measures, documents, and Library collections
     """
 
     V56 = "v56"
     V57 = "v57"
     V58 = "v58"
+    V63 = "v63"
 
     def __str__(self) -> str:
         """Return the version string for display."""
@@ -43,7 +46,7 @@ DEFAULT_METABASE_VERSION = MetabaseVersion.V56
 SUPPORTED_METABASE_VERSIONS: tuple[str, ...] = tuple(v.value for v in MetabaseVersion)
 
 # Type alias for version literals
-MetabaseVersionLiteral = Literal["v56", "v57", "v58"]
+MetabaseVersionLiteral = Literal["v56", "v57", "v58", "v63"]
 
 
 # =============================================================================

--- a/lib/handlers/dashboard.py
+++ b/lib/handlers/dashboard.py
@@ -343,6 +343,11 @@ class DashboardHandler(BaseHandler):
                 )
             )
 
+        # Preserve v63 filter-widget placement (header-/card-level filters).
+        # Parameter id strings are stable across import, so a straight copy is correct.
+        if dashcard.get("inline_parameters"):
+            clean_dashcard["inline_parameters"] = list(dashcard["inline_parameters"])
+
         # Remap series
         if dashcard.get("series"):
             clean_dashcard["series"] = self._remap_series(dashcard["series"])

--- a/lib/handlers/permissions.py
+++ b/lib/handlers/permissions.py
@@ -228,7 +228,35 @@ class PermissionsHandler(BaseHandler):
                 f"not included in the export: {sorted(unmapped_collections)}"
             )
 
+        self._fill_absent_collection_permissions(remapped_graph)
+
         return remapped_graph if remapped_graph["groups"] else {}
+
+    def _fill_absent_collection_permissions(self, remapped_graph: dict[str, Any]) -> None:
+        """Adds explicit "none" entries for group/collection pairs absent from the source.
+
+        Since Metabase 0.56.13 the collection graph omits "none" entries — absence
+        means no permission. PUT /collection/graph only overwrites pairs present in
+        the request, and newly created collections inherit their parent's
+        permissions on the target, so absent pairs must be sent explicitly as
+        "none" or source-side revocations silently become inherited access.
+
+        The Administrators group is excluded (its permissions are fixed in
+        Metabase), and the "root" collection is never synthesized — that would
+        alter access to pre-existing target content.
+        """
+        admin_source_ids = {
+            group.id
+            for group in self.context.manifest.permission_groups
+            if group.name == "Administrators"
+        }
+
+        for source_group_id, target_group_id in self.id_mapper.group_map.items():
+            if source_group_id in admin_source_ids:
+                continue
+            group_perms = remapped_graph["groups"].setdefault(str(target_group_id), {})
+            for target_coll_id in self.id_mapper.collection_map.values():
+                group_perms.setdefault(str(target_coll_id), "none")
 
     def _get_current_permissions_revision(self) -> int:
         """Gets the current permissions graph revision from target."""

--- a/lib/models_core.py
+++ b/lib/models_core.py
@@ -89,6 +89,8 @@ class Manifest:
     collection_permissions_graph: dict[str, Any] = dataclasses.field(default_factory=dict)
     # Database metadata: db_id -> {tables: [{id, name, fields: [{id, name}, ...]}, ...]}
     database_metadata: dict[int, dict[str, Any]] = dataclasses.field(default_factory=dict)
+    # v63 measures: [{id, name, description, table_id, definition}, ...]
+    measures: list[dict[str, Any]] = dataclasses.field(default_factory=list)
 
 
 # --- Import-specific Models ---

--- a/lib/remapping/id_mapper.py
+++ b/lib/remapping/id_mapper.py
@@ -37,6 +37,7 @@ class IDMapper:
         self._card_map: dict[int, int] = {}
         self._dashboard_map: dict[int, int] = {}
         self._group_map: dict[int, int] = {}
+        self._measure_map: dict[int, int] = {}
 
         # Table and field mappings: (source_db_id, source_id) -> target_id
         self._table_map: dict[tuple[int, int], int] = {}
@@ -68,6 +69,11 @@ class IDMapper:
         return self._group_map
 
     @property
+    def measure_map(self) -> dict[int, int]:
+        """Returns the measure ID mapping (v63)."""
+        return self._measure_map
+
+    @property
     def table_map(self) -> dict[tuple[int, int], int]:
         """Returns the table ID mapping."""
         return self._table_map
@@ -94,6 +100,10 @@ class IDMapper:
     def set_group_mapping(self, source_id: int, target_id: int) -> None:
         """Sets a permission group ID mapping."""
         self._group_map[source_id] = target_id
+
+    def set_measure_mapping(self, source_id: int, target_id: int) -> None:
+        """Sets a measure ID mapping (v63)."""
+        self._measure_map[source_id] = target_id
 
     # --- Database ID resolution ---
 
@@ -166,6 +176,17 @@ class IDMapper:
             The target card ID, or None if not mapped.
         """
         return self._card_map.get(source_card_id)
+
+    def resolve_measure_id(self, source_measure_id: int) -> int | None:
+        """Resolves a source measure ID to a target measure ID (v63).
+
+        Args:
+            source_measure_id: The source measure ID.
+
+        Returns:
+            The target measure ID, or None if not mapped.
+        """
+        return self._measure_map.get(source_measure_id)
 
     def resolve_dashboard_id(self, source_dashboard_id: int) -> int | None:
         """Resolves a source dashboard ID to a target dashboard ID.

--- a/lib/remapping/query_remapper.py
+++ b/lib/remapping/query_remapper.py
@@ -490,6 +490,27 @@ class QueryRemapper:
                 )
             return data
 
+        # v63 MBQL measure reference: ["measure", {metadata_dict}, measure_id]
+        # Measures are standalone table-scoped entities (not cards) referenced by ID.
+        if (
+            len(data) >= 3
+            and data[0] == "measure"
+            and isinstance(data[1], dict)
+            and isinstance(data[2], int)
+        ):
+            source_measure_id = data[2]
+            target_measure_id = self.id_mapper.resolve_measure_id(source_measure_id)
+            if target_measure_id:
+                result = list(data)
+                result[2] = target_measure_id
+                logger.debug(f"Remapped measure ID from {source_measure_id} to {target_measure_id}")
+                return result
+            logger.warning(
+                f"No measure ID mapping found for measure {source_measure_id}. "
+                f"Keeping original ID."
+            )
+            return data
+
         # Recursively process all items in the list
         return [self.remap_field_ids_recursively(item, source_db_id) for item in data]
 
@@ -535,17 +556,18 @@ class QueryRemapper:
             config["card_id"] = target_card_id
             logger.debug(f"Remapped parameter card_id {source_card_id} -> {target_card_id}")
 
-            # Remap field IDs in value_field
-            if "value_field" in config:
+            # Remap field IDs in value_field and label_field (v63 adds a separate
+            # "Column to supply the labels" stored as label_field)
+            field_keys = [key for key in ("value_field", "label_field") if key in config]
+            if field_keys:
                 source_db_id = self._find_card_database_id(source_card_id, manifest_cards)
                 if source_db_id:
-                    config["value_field"] = self.remap_field_ids_recursively(
-                        config["value_field"], source_db_id
-                    )
+                    for key in field_keys:
+                        config[key] = self.remap_field_ids_recursively(config[key], source_db_id)
                 else:
                     logger.warning(
                         f"Could not determine database ID for card {source_card_id}. "
-                        f"Field IDs in value_field will not be remapped."
+                        f"Field IDs in {', '.join(field_keys)} will not be remapped."
                     )
         else:
             # Card not found, remove values_source_config
@@ -762,15 +784,25 @@ class QueryRemapper:
                 if not isinstance(tag_data, dict):
                     remapped_list.append(tag_data)
                     continue
-                tag_name = str(tag_data.get("name") or "")
-                remapped_as_dict = self._remap_template_tags_dict(
-                    {tag_name: tag_data}, source_db_id
-                )
-                # Card tags may change their key/name; take the remapped value.
-                remapped_list.append(next(iter(remapped_as_dict.values())))
+                remapped_list.append(self._remap_single_tag(tag_data, source_db_id))
             return remapped_list
 
         return self._remap_template_tags_dict(template_tags, source_db_id)
+
+    def _remap_single_tag(self, tag_data: dict[str, Any], source_db_id: int) -> dict[str, Any]:
+        """Remaps one list-form template tag via the dict-based remapping logic."""
+        tag_name = str(tag_data.get("name") or "")
+        remapped_as_dict = self._remap_template_tags_dict({tag_name: tag_data}, source_db_id)
+        # The dict path must emit exactly one entry per input entry (card tags may
+        # change their key); if that invariant ever breaks, keep the original tag
+        # rather than raising StopIteration mid-import.
+        if len(remapped_as_dict) != 1:
+            logger.warning(
+                f"Template tag '{tag_name}' remapping produced "
+                f"{len(remapped_as_dict)} entries; keeping original tag."
+            )
+            return tag_data
+        return next(iter(remapped_as_dict.values()))
 
     def _remap_template_tags_dict(
         self, template_tags: dict[str, Any], source_db_id: int = 0
@@ -834,10 +866,67 @@ class QueryRemapper:
                     )
                     continue
 
+            elif tag_data.get("type") == "table":
+                # v63 Table Variables: the tag stores a raw source table ID in
+                # "table-id" and optional "source-filters" entries each holding
+                # a raw "field-id".
+                remapped_tags[tag_name] = self._remap_table_tag(tag_name, tag_data, source_db_id)
+                continue
+
             # Non-card/non-field tags or unmapped card tags - keep as-is
             remapped_tags[tag_name] = tag_data
 
         return remapped_tags
+
+    def _remap_table_tag(
+        self, tag_name: str, tag_data: dict[str, Any], source_db_id: int
+    ) -> dict[str, Any]:
+        """Remaps table and field IDs in a v63 "table" template tag (Table Variables).
+
+        Args:
+            tag_name: The tag name (for logging).
+            tag_data: The tag dictionary containing "table-id" and optional
+                "source-filters" entries with "field-id" values.
+            source_db_id: The source database ID for table/field lookups.
+
+        Returns:
+            A deep copy of the tag with table and field IDs remapped.
+        """
+        tag_data_copy = copy.deepcopy(tag_data)
+
+        source_table_id = tag_data_copy.get("table-id")
+        if isinstance(source_table_id, int):
+            target_table_id = self.id_mapper.resolve_table_id(source_db_id, source_table_id)
+            if target_table_id:
+                tag_data_copy["table-id"] = target_table_id
+                logger.debug(
+                    f"Remapped table tag '{tag_name}' table-id "
+                    f"{source_table_id} -> {target_table_id}"
+                )
+            else:
+                logger.warning(
+                    f"No table mapping found for template tag '{tag_name}' "
+                    f"with table-id {source_table_id}. Keeping original."
+                )
+
+        source_filters = tag_data_copy.get("source-filters")
+        if isinstance(source_filters, list):
+            for source_filter in source_filters:
+                if not isinstance(source_filter, dict):
+                    continue
+                source_field_id = source_filter.get("field-id")
+                if not isinstance(source_field_id, int):
+                    continue
+                target_field_id = self.id_mapper.resolve_field_id(source_db_id, source_field_id)
+                if target_field_id:
+                    source_filter["field-id"] = target_field_id
+                else:
+                    logger.warning(
+                        f"No field mapping found for source-filter field-id "
+                        f"{source_field_id} in table tag '{tag_name}'. Keeping original."
+                    )
+
+        return tag_data_copy
 
     def _remap_tag_name(self, tag_name: str, source_card_id: int, target_card_id: int) -> str:
         """Remaps a template tag name by replacing the old card ID with the new one.

--- a/lib/services/export_service.py
+++ b/lib/services/export_service.py
@@ -15,6 +15,7 @@ from lib.constants import (
     SOURCE_TABLE_KEY,
     STAGES_KEY,
     V57_SOURCE_CARD_KEY,
+    MetabaseVersion,
 )
 from lib.models import Card, Collection, Dashboard, Manifest, ManifestMeta, PermissionGroup
 from lib.utils import (
@@ -50,6 +51,7 @@ class ExportService:
         self._collection_path_map: dict[int, str] = {}
         self._processed_collections: set[int] = set()
         self._exported_cards: set[int] = set()  # Track exported cards to prevent duplicates
+        self._skipped_documents: list[str] = []  # v63 documents found but not migrated
         self._dependency_chain: list[int] = (
             []
         )  # Track current dependency chain for circular detection
@@ -91,7 +93,23 @@ class ExportService:
             self._fetch_and_store_databases()
 
             logger.info("Fetching collection tree...")
-            collection_tree = self.client.get_collections_tree()
+            tree_params: dict[str, Any] = {}
+            if self.config.include_library:
+                if self.config.metabase_version == MetabaseVersion.V63:
+                    # v63 excludes the Library (Data Studio) subtree from the
+                    # collection tree unless explicitly requested.
+                    tree_params["include-library"] = "true"
+                else:
+                    logger.warning(
+                        "--include-library is only supported for Metabase v63; ignoring."
+                    )
+            if tree_params:
+                collection_tree = self.client.get_collections_tree(params=tree_params)
+            else:
+                # Regression guard: never pass params here unless required —
+                # e.g. {"archived": "true"} makes the API return only archived
+                # collections instead of the full tree.
+                collection_tree = self.client.get_collections_tree()
 
             # Filter tree if root_collection_ids are specified
             if self.config.root_collection_ids:
@@ -120,6 +138,10 @@ class ExportService:
                 logger.info("Exporting permissions...")
                 self._export_permissions()
 
+            # Export measures (v63 Data Studio saved aggregations)
+            if self.config.metabase_version == MetabaseVersion.V63:
+                self._export_measures()
+
             # Write the final manifest file
             manifest_path = self.export_dir / "manifest.json"
             logger.info(f"Writing manifest to {manifest_path}")
@@ -134,6 +156,13 @@ class ExportService:
             logger.info(f"  Databases: {len(self.manifest.databases)}")
             if self.config.include_permissions:
                 logger.info(f"  Permission Groups: {len(self.manifest.permission_groups)}")
+            if self.manifest.measures:
+                logger.info(f"  Measures: {len(self.manifest.measures)}")
+            if self._skipped_documents:
+                logger.warning(
+                    f"  Documents skipped (migration not supported): "
+                    f"{len(self._skipped_documents)}"
+                )
             logger.info("=" * 80)
             logger.info("Export completed successfully.")
 
@@ -185,6 +214,47 @@ class ExportService:
             except Exception as e:
                 logger.warning(f"Failed to fetch metadata for database {db_id}: {e}")
                 # Continue with other databases
+
+    def _export_measures(self) -> None:
+        """Exports v63 measures (Data Studio saved aggregations) into the manifest.
+
+        Only measures attached to tables of exported databases are kept — the
+        importer needs the table in the database metadata to remap it.
+        """
+        logger.info("Fetching measures...")
+        try:
+            measures = self.client.get_measures()
+        except MetabaseAPIError as e:
+            logger.warning(f"Failed to fetch measures: {e}. Continuing without measures.")
+            return
+
+        known_table_ids = {
+            table["id"]
+            for metadata in self.manifest.database_metadata.values()
+            for table in metadata.get("tables", [])
+        }
+
+        for measure in measures:
+            if measure.get("archived"):
+                continue
+            table_id = measure.get("table_id")
+            if table_id not in known_table_ids:
+                logger.debug(
+                    f"Skipping measure '{measure.get('name')}' (ID: {measure.get('id')}): "
+                    f"table {table_id} is not part of the exported databases."
+                )
+                continue
+            self.manifest.measures.append(
+                {
+                    "id": measure.get("id"),
+                    "name": measure.get("name"),
+                    "description": measure.get("description"),
+                    "table_id": table_id,
+                    "definition": measure.get("definition"),
+                }
+            )
+
+        logger.info(f"Exported {len(self.manifest.measures)} measure(s).")
 
     def _traverse_collections(
         self, collections: list[dict], parent_path: str = "", parent_id: int | None = None
@@ -274,8 +344,13 @@ class ExportService:
             # Use pinned_state="all" to get both pinned and non-pinned items.
             # Note: archived items never appear in collection item listings — they are
             # fetched separately via _export_archived_cards() when include_archived=True.
+            models = ["card", "dashboard", "dataset", "metric"]
+            if self.config.metabase_version == MetabaseVersion.V63:
+                # v63 collections can also contain documents; request them so the
+                # export can report what the migration does not carry.
+                models.append("document")
             params = {
-                "models": ["card", "dashboard", "dataset", "metric"],
+                "models": models,
                 "archived": "false",
                 "pinned_state": "all",
             }
@@ -298,6 +373,14 @@ class ExportService:
                     )
                 elif model == "dashboard" and self.config.include_dashboards:
                     self._export_dashboard(item["id"], base_path)
+                elif model == "document":
+                    document_name = item.get("name") or f"id={item.get('id')}"
+                    self._skipped_documents.append(document_name)
+                    logger.warning(
+                        f"Skipping document '{document_name}' (ID: {item.get('id')}) in "
+                        f"collection {collection_id}: document migration is not supported. "
+                        f"Recreate it manually on the target instance."
+                    )
 
         except MetabaseAPIError as e:
             logger.error(f"Failed to process items for collection {collection_id}: {e}")

--- a/lib/services/import_service.py
+++ b/lib/services/import_service.py
@@ -163,6 +163,7 @@ class ImportService:
             permissions_graph=manifest_data.get("permissions_graph", {}),
             collection_permissions_graph=manifest_data.get("collection_permissions_graph", {}),
             database_metadata=database_metadata_with_int_keys,
+            measures=manifest_data.get("measures", []),
         )
 
     def _validate_metabase_version(self) -> None:
@@ -344,6 +345,7 @@ class ImportService:
         context = self._get_context()
         logger.info("Pre-fetching target collection items for conflict detection...")
         context.prefetch_collection_items()
+        self._import_measures()
         self._import_cards()
         if manifest.dashboards:
             self._import_dashboards()
@@ -366,6 +368,92 @@ class ImportService:
         manifest = self._get_manifest()
         handler = CollectionHandler(context)
         handler.import_collections(manifest.collections)
+
+    def _import_measures(self) -> None:
+        """Imports v63 measures and records source->target measure ID mappings.
+
+        Measures must exist before cards are imported because card aggregations
+        reference them via ["measure", {...}, measure_id] clauses. Existing
+        target measures are matched by (table_id, name) so re-imports are
+        idempotent.
+        """
+        manifest = self._get_manifest()
+        if not manifest.measures:
+            return
+
+        id_mapper = self._get_id_mapper()
+        query_remapper = self._query_remapper
+        if query_remapper is None:
+            raise RuntimeError("Query remapper not initialized")
+
+        logger.info(f"Importing {len(manifest.measures)} measure(s)...")
+
+        try:
+            existing = {
+                (measure.get("table_id"), measure.get("name")): measure.get("id")
+                for measure in self.client.get_measures()
+            }
+        except MetabaseAPIError as e:
+            logger.warning(f"Could not list target measures: {e}")
+            existing = {}
+
+        # table_id -> source db id lookup from manifest metadata
+        table_to_db: dict[int, int] = {}
+        for db_id, metadata in manifest.database_metadata.items():
+            for table in metadata.get("tables", []):
+                table_to_db[table["id"]] = db_id
+
+        for measure in manifest.measures:
+            source_measure_id = measure.get("id")
+            name = measure.get("name")
+            source_table_id = measure.get("table_id")
+            if source_measure_id is None or name is None or not isinstance(source_table_id, int):
+                logger.warning(f"Skipping measure '{name}': incomplete manifest entry.")
+                continue
+
+            source_db_id = table_to_db.get(source_table_id)
+            if source_db_id is None:
+                logger.warning(
+                    f"Skipping measure '{name}': table {source_table_id} not found "
+                    f"in the export's database metadata."
+                )
+                continue
+
+            target_table_id = id_mapper.resolve_table_id(source_db_id, source_table_id)
+            if not target_table_id:
+                logger.warning(
+                    f"Skipping measure '{name}': no table mapping for source table "
+                    f"{source_table_id} (database {source_db_id})."
+                )
+                continue
+
+            existing_id = existing.get((target_table_id, name))
+            if existing_id:
+                id_mapper.set_measure_mapping(source_measure_id, existing_id)
+                logger.info(f"Measure '{name}' already exists on target (ID: {existing_id}).")
+                continue
+
+            definition = query_remapper.remap_field_ids_recursively(
+                measure.get("definition") or {}, source_db_id
+            )
+            payload: dict[str, Any] = {
+                "name": name,
+                "table_id": target_table_id,
+                "definition": definition,
+            }
+            if measure.get("description"):
+                payload["description"] = measure["description"]
+
+            try:
+                created = self.client.create_measure(payload)
+                target_id = created.get("id") if isinstance(created, dict) else None
+                if target_id:
+                    id_mapper.set_measure_mapping(source_measure_id, target_id)
+                    logger.info(f"Created measure '{name}' (ID: {target_id}).")
+                else:
+                    logger.warning(f"Measure '{name}' was created but returned no ID.")
+            except MetabaseAPIError as e:
+                logger.error(f"Failed to create measure '{name}': {e}")
 
     def _import_cards(self) -> None:
         """Imports cards using the CardHandler."""

--- a/lib/version.py
+++ b/lib/version.py
@@ -626,6 +626,23 @@ class V58Adapter(VersionAdapter):
 
 
 # =============================================================================
+# Version 63 Adapter Implementation
+# =============================================================================
+
+
+class V63Adapter(V58Adapter):
+    """Version adapter for Metabase v63.
+
+    v63 uses the same MBQL 5 format and API endpoints as v58. The semantic
+    differences are handled elsewhere in the toolkit:
+    - template-tags may be serialized as a list of tag objects (metabase#77133)
+    - new "table" template-tag type (Table Variables) with raw table/field IDs
+    - measures referenced from aggregations as ["measure", {...}, id]
+    - documents and Library collections (detected and reported during export)
+    """
+
+
+# =============================================================================
 # Version Adapter Factory
 # =============================================================================
 
@@ -649,6 +666,15 @@ _VERSION_CONFIGS: dict[MetabaseVersion, VersionConfig] = {
     ),
     MetabaseVersion.V58: VersionConfig(
         version=MetabaseVersion.V58,
+        api_endpoints=APIEndpoints(),
+        mbql_config=MBQLConfig(
+            uses_stages=True,
+            filter_key="filters",
+        ),
+        dashboard_config=DashboardConfig(),
+    ),
+    MetabaseVersion.V63: VersionConfig(
+        version=MetabaseVersion.V63,
         api_endpoints=APIEndpoints(),
         mbql_config=MBQLConfig(
             uses_stages=True,
@@ -698,6 +724,9 @@ def get_version_adapter(version: MetabaseVersion) -> VersionAdapter:
 
     if version == MetabaseVersion.V58:
         return V58Adapter(config)
+
+    if version == MetabaseVersion.V63:
+        return V63Adapter(config)
 
     raise ValueError(f"No adapter implementation for version: {version}")
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -19,13 +19,15 @@ The integration tests use Docker Compose to spin up:
 
 ## Metabase Version Support
 
-The integration tests support both Metabase v56 and v57. The version determines which Docker Compose file and query
-format is used.
+The integration tests support Metabase v56, v57, v58, and v63. The version determines which Docker Compose file
+and query format is used.
 
 | Version | Docker Compose File           | Metabase Image                  | Query Format     |
 |---------|-------------------------------|---------------------------------|------------------|
 | `v56`   | `docker-compose.test.yml`     | `metabase/metabase:v0.56.1`     | MBQL 4           |
 | `v57`   | `docker-compose.test.v57.yml` | `metabase/metabase:v0.57.2`     | MBQL 5 (stages)  |
+| `v58`   | `docker-compose.test.v58.yml` | `metabase/metabase:v0.58.0`     | MBQL 5 (stages)  |
+| `v63`   | `docker-compose.test.v63.yml` | `metabase/metabase:v0.63.14`    | MBQL 5 (stages)  |
 
 ### Running Tests with Different Versions
 
@@ -35,6 +37,9 @@ make test-integration
 
 # Run with v57
 MB_METABASE_VERSION=v57 make test-integration
+
+# Run with v63
+MB_METABASE_VERSION=v63 pytest tests/integration/test_e2e_export_import.py -v -s -m integration
 
 # Or directly with pytest
 MB_METABASE_VERSION=v57 pytest tests/integration/ -v -s

--- a/tests/integration/test_comprehensive_e2e.py
+++ b/tests/integration/test_comprehensive_e2e.py
@@ -64,6 +64,8 @@ def get_metabase_version() -> MetabaseVersion:
         return MetabaseVersion.V57
     if version_str == "v58":
         return MetabaseVersion.V58
+    if version_str == "v63":
+        return MetabaseVersion.V63
     return DEFAULT_METABASE_VERSION
 
 
@@ -77,9 +79,18 @@ def is_v58() -> bool:
     return get_metabase_version() == MetabaseVersion.V58
 
 
+def is_v63() -> bool:
+    """Check if we're testing against v63."""
+    return get_metabase_version() == MetabaseVersion.V63
+
+
 def is_mbql5() -> bool:
     """Check if we're testing against a version that uses MBQL 5 (stages format)."""
-    return get_metabase_version() in (MetabaseVersion.V57, MetabaseVersion.V58)
+    return get_metabase_version() in (
+        MetabaseVersion.V57,
+        MetabaseVersion.V58,
+        MetabaseVersion.V63,
+    )
 
 
 # =============================================================================
@@ -91,6 +102,8 @@ def is_mbql5() -> bool:
 def docker_compose_file():
     """Return path to docker-compose file based on MB_METABASE_VERSION."""
     base_path = Path(__file__).parent.parent.parent
+    if is_v63():
+        return base_path / "docker-compose.test.v63.yml"
     if is_v58():
         return base_path / "docker-compose.test.v58.yml"
     if is_v57():

--- a/tests/integration/test_e2e_export_import.py
+++ b/tests/integration/test_e2e_export_import.py
@@ -34,6 +34,7 @@ from export_metabase import MetabaseExporter
 from import_metabase import MetabaseImporter
 from lib.config import ExportConfig, ImportConfig
 from lib.constants import DEFAULT_METABASE_VERSION, MetabaseVersion
+from lib.utils.query import iter_template_tags
 from tests.integration.test_helpers import MetabaseTestHelper
 
 logger = logging.getLogger(__name__)
@@ -62,6 +63,8 @@ def get_metabase_version() -> MetabaseVersion:
         return MetabaseVersion.V57
     if version_str == "v58":
         return MetabaseVersion.V58
+    if version_str == "v63":
+        return MetabaseVersion.V63
     return DEFAULT_METABASE_VERSION
 
 
@@ -75,9 +78,18 @@ def is_v58() -> bool:
     return get_metabase_version() == MetabaseVersion.V58
 
 
+def is_v63() -> bool:
+    """Check if we're testing against v63."""
+    return get_metabase_version() == MetabaseVersion.V63
+
+
 def is_mbql5() -> bool:
     """Check if we're testing against a version that uses MBQL 5 (stages format)."""
-    return get_metabase_version() in (MetabaseVersion.V57, MetabaseVersion.V58)
+    return get_metabase_version() in (
+        MetabaseVersion.V57,
+        MetabaseVersion.V58,
+        MetabaseVersion.V63,
+    )
 
 
 def get_query_from_card(card: dict[str, Any]) -> dict[str, Any]:
@@ -223,37 +235,44 @@ def is_native_query(card: dict[str, Any]) -> bool:
 
 
 def get_template_tags_from_card(card: dict[str, Any]) -> dict[str, Any]:
-    """Get template tags from a native query card, handling both v56 and v57 formats.
+    """Get template tags from a native query card, handling v56, v57, and v63 formats.
 
     v56: dataset_query.native.template-tags
     v57: dataset_query.stages[0].template-tags (or top-level template-tags)
+    v63: same locations, but serialized as a list of tag objects (metabase#77133)
+
+    The result is always normalized to a name-keyed dict so assertions can use
+    a single shape regardless of the API's serialization.
 
     Args:
         card: The card data dictionary.
 
     Returns:
-        The template tags dictionary, or empty dict if not found.
+        The template tags as a name-keyed dictionary, or empty dict if not found.
     """
     dataset_query = card.get("dataset_query", {})
+
+    def normalize(tags: Any) -> dict[str, Any]:
+        return dict(iter_template_tags(tags))
 
     # v57 uses stages with template-tags
     stages = dataset_query.get("stages", [])
     if stages and isinstance(stages, list) and len(stages) > 0:
         stage = stages[0]
         if isinstance(stage, dict):
-            tags = stage.get("template-tags", {})
+            tags = stage.get("template-tags")
             if tags:
-                return tags
+                return normalize(tags)
 
     # Also check top-level template-tags in v57
-    top_level_tags = dataset_query.get("template-tags", {})
+    top_level_tags = dataset_query.get("template-tags")
     if top_level_tags:
-        return top_level_tags
+        return normalize(top_level_tags)
 
     # v56 uses native.template-tags
     native = dataset_query.get("native", {})
     if isinstance(native, dict):
-        return native.get("template-tags", {})
+        return normalize(native.get("template-tags", {}))
 
     return {}
 
@@ -373,6 +392,8 @@ def docker_compose_file():
     Uses docker-compose.test.yml for v56 (default), version-specific files for v57/v58.
     """
     base_path = Path(__file__).parent.parent.parent
+    if is_v63():
+        return base_path / "docker-compose.test.v63.yml"
     if is_v58():
         return base_path / "docker-compose.test.v58.yml"
     if is_v57():

--- a/tests/test_v63_support.py
+++ b/tests/test_v63_support.py
@@ -1,0 +1,620 @@
+"""
+Tests for Metabase v63 support.
+
+Covers the v63 version adapter, "table" template-tag remapping (Table
+Variables), list-form template-tag edge cases, measure clause remapping and
+measure migration, parameter label_field remapping, dashcard
+inline_parameters preservation, document detection during export, the
+--include-library flag, and explicit "none" collection-permission filling.
+"""
+
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+from lib.config import ExportConfig, ImportConfig
+from lib.constants import SUPPORTED_METABASE_VERSIONS, MetabaseVersion
+from lib.handlers.base import ImportContext
+from lib.handlers.dashboard import DashboardHandler
+from lib.handlers.permissions import PermissionsHandler
+from lib.models import Card, DatabaseMap, ImportReport, Manifest, ManifestMeta, PermissionGroup
+from lib.remapping.id_mapper import IDMapper
+from lib.remapping.query_remapper import QueryRemapper
+from lib.services.export_service import ExportService
+from lib.services.import_service import ImportService
+from lib.version import V63Adapter, get_version_adapter, get_version_config
+
+
+def _make_manifest(databases: dict[int, str] | None = None) -> Manifest:
+    return Manifest(
+        meta=ManifestMeta(
+            source_url="https://source.example.com",
+            export_timestamp="2026-01-01T00:00:00",
+            tool_version="1.0.0",
+            cli_args={},
+        ),
+        databases=databases or {},
+    )
+
+
+def _make_id_mapper(
+    db_mapping: dict[int, int] | None = None,
+    card_mapping: dict[int, int] | None = None,
+) -> IDMapper:
+    db_mapping = db_mapping or {}
+    card_mapping = card_mapping or {}
+    manifest = _make_manifest({source_id: f"DB{source_id}" for source_id in db_mapping})
+    db_map = DatabaseMap(by_id={str(k): v for k, v in db_mapping.items()})
+    mapper = IDMapper(manifest, db_map)
+    for source_id, target_id in card_mapping.items():
+        mapper.set_card_mapping(source_id, target_id)
+    return mapper
+
+
+def _make_export_config(**overrides) -> ExportConfig:
+    defaults = {
+        "source_url": "https://source.example.com",
+        "export_dir": "./test_export",
+        "source_username": "test@example.com",
+        "source_password": "password123",  # pragma: allowlist secret
+        "metabase_version": MetabaseVersion.V63,
+    }
+    defaults.update(overrides)
+    return ExportConfig(**defaults)
+
+
+class TestV63VersionSupport:
+    """Tests for the v63 version enum and adapter."""
+
+    def test_v63_in_supported_versions(self):
+        assert "v63" in SUPPORTED_METABASE_VERSIONS
+
+    def test_get_version_adapter_returns_v63_adapter(self):
+        adapter = get_version_adapter(MetabaseVersion.V63)
+        assert isinstance(adapter, V63Adapter)
+        assert adapter.version == MetabaseVersion.V63
+
+    def test_v63_uses_stages(self):
+        config = get_version_config(MetabaseVersion.V63)
+        assert config.mbql_config.uses_stages is True
+
+    def test_v63_dependency_extraction_matches_v58(self):
+        """v63 inherits v58 dependency extraction (stages, card tags, list form)."""
+        card_data = {
+            "dataset_query": {
+                "lib/type": "mbql/query",
+                "stages": [
+                    {
+                        "lib/type": "mbql.stage/native",
+                        "native": "SELECT * FROM {{#50-model}}",
+                        "template-tags": [{"type": "card", "name": "50-model", "card-id": 50}],
+                    },
+                    {"lib/type": "mbql.stage/mbql", "source-table": "card__60"},
+                ],
+            }
+        }
+        v58 = get_version_adapter(MetabaseVersion.V58)
+        v63 = get_version_adapter(MetabaseVersion.V63)
+        assert v63.extract_card_dependencies(card_data) == {50, 60}
+        assert v63.extract_card_dependencies(card_data) == v58.extract_card_dependencies(card_data)
+
+
+class TestTableTemplateTagRemapping:
+    """Tests for v63 "table" template tags (Table Variables)."""
+
+    @pytest.fixture
+    def remapper(self):
+        id_mapper = _make_id_mapper(db_mapping={1: 100}, card_mapping={50: 500})
+        id_mapper._table_map[(1, 27)] = 42
+        id_mapper._field_map[(1, 159)] = 301
+        return QueryRemapper(id_mapper)
+
+    def test_remap_table_tag_dict_form(self, remapper):
+        tags = {
+            "invoices": {
+                "type": "table",
+                "name": "invoices",
+                "display-name": "Invoices",
+                "table-id": 27,
+                "alias": "inv",
+                "source-filters": [{"field-id": 159, "op": "=", "value": "open"}],
+            }
+        }
+        result = remapper._remap_template_tags(tags, source_db_id=1)
+
+        assert result["invoices"]["table-id"] == 42
+        assert result["invoices"]["source-filters"][0]["field-id"] == 301
+        assert result["invoices"]["alias"] == "inv"
+        # The original tag must not be mutated
+        assert tags["invoices"]["table-id"] == 27
+        assert tags["invoices"]["source-filters"][0]["field-id"] == 159
+
+    def test_remap_table_tag_list_form(self, remapper):
+        tags = [
+            {
+                "type": "table",
+                "name": "invoices",
+                "table-id": 27,
+                "source-filters": [{"field-id": 159, "op": "=", "value": "open"}],
+            },
+            {"type": "text", "name": "client"},
+        ]
+        result = remapper._remap_template_tags(tags, source_db_id=1)
+
+        assert isinstance(result, list)
+        assert result[0]["table-id"] == 42
+        assert result[0]["source-filters"][0]["field-id"] == 301
+        assert result[1] == {"type": "text", "name": "client"}
+
+    def test_remap_table_tag_unmapped_ids_kept(self, remapper):
+        tags = {
+            "orders": {
+                "type": "table",
+                "name": "orders",
+                "table-id": 999,
+                "source-filters": [{"field-id": 888, "op": "=", "value": "x"}],
+            }
+        }
+        result = remapper._remap_template_tags(tags, source_db_id=1)
+
+        assert result["orders"]["table-id"] == 999
+        assert result["orders"]["source-filters"][0]["field-id"] == 888
+
+    def test_remap_table_tag_in_card_data(self, remapper):
+        """End-to-end: a v63 stages-form card with a table tag remaps cleanly."""
+        card_data = {
+            "database_id": 1,
+            "dataset_query": {
+                "lib/type": "mbql/query",
+                "database": 1,
+                "stages": [
+                    {
+                        "lib/type": "mbql.stage/native",
+                        "native": "SELECT * FROM {{invoices}}",
+                        "template-tags": [{"type": "table", "name": "invoices", "table-id": 27}],
+                    }
+                ],
+            },
+        }
+        result, success = remapper.remap_card_data(card_data)
+
+        assert success is True
+        tags = result["dataset_query"]["stages"][0]["template-tags"]
+        assert tags[0]["table-id"] == 42
+
+
+class TestListFormTemplateTagEdgeCases:
+    """Edge cases for list-form template-tags not covered by the base tests."""
+
+    @pytest.fixture
+    def remapper(self):
+        return QueryRemapper(_make_id_mapper(db_mapping={1: 100}, card_mapping={50: 500}))
+
+    def test_non_dict_entries_pass_through(self, remapper):
+        tags = ["garbage", {"type": "text", "name": "client"}, 42]
+        result = remapper._remap_template_tags(tags, source_db_id=1)
+
+        assert result == ["garbage", {"type": "text", "name": "client"}, 42]
+
+    def test_unmapped_card_tag_kept(self, remapper):
+        tags = [{"type": "card", "name": "99-missing", "card-id": 99}]
+        result = remapper._remap_template_tags(tags, source_db_id=1)
+
+        assert result[0]["card-id"] == 99
+        assert result[0]["name"] == "99-missing"
+
+    def test_duplicate_names_preserved(self, remapper):
+        tags = [
+            {"type": "text", "name": "dup", "id": "a"},
+            {"type": "text", "name": "dup", "id": "b"},
+        ]
+        result = remapper._remap_template_tags(tags, source_db_id=1)
+
+        assert len(result) == 2
+        assert {tag["id"] for tag in result} == {"a", "b"}
+
+
+class TestMeasureClauseRemapping:
+    """Tests for v63 ["measure", {...}, id] clause remapping."""
+
+    def test_remap_measure_clause(self):
+        id_mapper = _make_id_mapper(db_mapping={1: 100})
+        id_mapper.set_measure_mapping(5, 77)
+        remapper = QueryRemapper(id_mapper)
+
+        clause = ["measure", {"lib/uuid": "x"}, 5]
+        result = remapper.remap_field_ids_recursively(clause, 1)
+
+        assert result == ["measure", {"lib/uuid": "x"}, 77]
+
+    def test_unmapped_measure_clause_kept(self):
+        remapper = QueryRemapper(_make_id_mapper(db_mapping={1: 100}))
+
+        clause = ["measure", {"lib/uuid": "x"}, 5]
+        result = remapper.remap_field_ids_recursively(clause, 1)
+
+        assert result[2] == 5
+
+
+class TestParameterLabelFieldRemapping:
+    """Tests for v63 values_source_config.label_field remapping."""
+
+    def test_label_field_remapped_alongside_value_field(self):
+        id_mapper = _make_id_mapper(db_mapping={2: 2}, card_mapping={232: 501})
+        id_mapper._field_map[(2, 159)] = 301
+        id_mapper._field_map[(2, 160)] = 302
+        remapper = QueryRemapper(id_mapper)
+
+        card_data = {
+            "database_id": 2,
+            "dataset_query": {
+                "type": "native",
+                "native": {"query": "SELECT 1 WHERE client = {{client}}"},
+            },
+            "parameters": [
+                {
+                    "name": "Client",
+                    "values_source_type": "card",
+                    "values_source_config": {
+                        "card_id": 232,
+                        "value_field": ["field", {"lib/uuid": "v"}, 159],
+                        "label_field": ["field", {"lib/uuid": "l"}, 160],
+                    },
+                }
+            ],
+        }
+        manifest_cards = [
+            Card(
+                id=232,
+                name="Client list",
+                collection_id=20,
+                database_id=2,
+                file_path="cards/card_232.json",
+                checksum="abc",
+            )
+        ]
+
+        remapped_data, success = remapper.remap_card_data(card_data, manifest_cards)
+
+        assert success is True
+        config = remapped_data["parameters"][0]["values_source_config"]
+        assert config["card_id"] == 501
+        assert config["value_field"][2] == 301
+        assert config["label_field"][2] == 302
+
+
+class TestInlineParametersPreserved:
+    """Tests for v63 dashcard inline_parameters (filter-widget placement)."""
+
+    @pytest.fixture
+    def import_context(self, tmp_path):
+        id_mapper = Mock(spec=IDMapper)
+        id_mapper.resolve_card_id.return_value = 999
+        query_remapper = Mock(spec=QueryRemapper)
+        query_remapper.remap_dashcard_visualization_settings.side_effect = lambda x, _: x
+        manifest = Mock(spec=Manifest)
+        manifest.cards = []
+        config = Mock(spec=ImportConfig)
+        config.conflict_strategy = "skip"
+        return ImportContext(
+            config=config,
+            client=Mock(),
+            manifest=manifest,
+            export_dir=tmp_path,
+            id_mapper=id_mapper,
+            query_remapper=query_remapper,
+            report=Mock(spec=ImportReport),
+            target_collections=[],
+        )
+
+    def test_inline_parameters_copied(self, import_context):
+        dashcard = {
+            "id": 1,
+            "card_id": 1,
+            "row": 0,
+            "col": 0,
+            "size_x": 6,
+            "size_y": 4,
+            "inline_parameters": ["abc-123", "def-456"],
+        }
+        handler = DashboardHandler(import_context)
+        result = handler._prepare_single_dashcard(dashcard, temp_id=-1)
+
+        assert result["inline_parameters"] == ["abc-123", "def-456"]
+
+    def test_inline_parameters_absent(self, import_context):
+        dashcard = {"id": 1, "card_id": 1, "row": 0, "col": 0, "size_x": 6, "size_y": 4}
+        handler = DashboardHandler(import_context)
+        result = handler._prepare_single_dashcard(dashcard, temp_id=-1)
+
+        assert "inline_parameters" not in result
+
+    def test_inline_parameters_null_dropped(self, import_context):
+        dashcard = {
+            "id": 1,
+            "card_id": 1,
+            "row": 0,
+            "col": 0,
+            "size_x": 6,
+            "size_y": 4,
+            "inline_parameters": None,
+        }
+        handler = DashboardHandler(import_context)
+        result = handler._prepare_single_dashcard(dashcard, temp_id=-1)
+
+        assert "inline_parameters" not in result
+
+
+class TestCollectionPermissionsNoneFill:
+    """Tests for explicit "none" filling in the collection permissions graph."""
+
+    @pytest.fixture
+    def import_context(self, tmp_path):
+        manifest = Mock(spec=Manifest)
+        manifest.permission_groups = [
+            PermissionGroup(id=2, name="Administrators", member_count=1),
+            PermissionGroup(id=3, name="Analysts", member_count=5),
+            PermissionGroup(id=4, name="Viewers", member_count=10),
+        ]
+        manifest.collection_permissions_graph = {
+            "revision": 1,
+            "groups": {
+                "3": {"10": "write", "20": "read"},
+                "4": {"10": "read", "root": "none"},
+            },
+        }
+        id_mapper = Mock(spec=IDMapper)
+        id_mapper.group_map = {}
+        id_mapper.collection_map = {}
+        client = Mock()
+        client.get_collection_permissions_graph.return_value = {"revision": 3}
+        return ImportContext(
+            config=Mock(spec=ImportConfig),
+            client=client,
+            manifest=manifest,
+            export_dir=tmp_path,
+            id_mapper=id_mapper,
+            query_remapper=Mock(spec=QueryRemapper),
+            report=Mock(spec=ImportReport),
+            target_collections=[],
+        )
+
+    def test_absent_pairs_filled_with_none(self, import_context):
+        id_mapper = import_context.id_mapper
+        id_mapper.group_map = {3: 100, 4: 101}
+        id_mapper.collection_map = {10: 1010, 20: 1020}
+        id_mapper.resolve_collection_id.side_effect = lambda x: {10: 1010, 20: 1020}.get(x)
+
+        handler = PermissionsHandler(import_context)
+        result = handler._remap_collection_permissions_graph(
+            import_context.manifest.collection_permissions_graph
+        )
+
+        assert result["groups"]["100"] == {"1010": "write", "1020": "read"}
+        # Group 4 had no entry for collection 20 -> explicit "none"
+        assert result["groups"]["101"]["1010"] == "read"
+        assert result["groups"]["101"]["1020"] == "none"
+        # Root pass-through is untouched and never synthesized
+        assert result["groups"]["101"]["root"] == "none"
+        assert "root" not in result["groups"]["100"]
+
+    def test_group_absent_from_graph_gets_all_none(self, import_context):
+        id_mapper = import_context.id_mapper
+        id_mapper.group_map = {3: 100, 5: 105}  # group 5 has no graph entries
+        id_mapper.collection_map = {10: 1010}
+        id_mapper.resolve_collection_id.side_effect = lambda x: {10: 1010, 20: None}.get(x)
+        import_context.manifest.permission_groups.append(
+            PermissionGroup(id=5, name="Auditors", member_count=2)
+        )
+
+        handler = PermissionsHandler(import_context)
+        result = handler._remap_collection_permissions_graph(
+            import_context.manifest.collection_permissions_graph
+        )
+
+        assert result["groups"]["105"] == {"1010": "none"}
+
+    def test_administrators_not_filled(self, import_context):
+        id_mapper = import_context.id_mapper
+        id_mapper.group_map = {2: 999}  # only the Administrators group is mapped
+        id_mapper.collection_map = {10: 1010}
+        id_mapper.resolve_collection_id.return_value = None
+
+        handler = PermissionsHandler(import_context)
+        result = handler._remap_collection_permissions_graph(
+            import_context.manifest.collection_permissions_graph
+        )
+
+        assert result == {}
+
+
+class TestV63DocumentDetection:
+    """Tests for detecting (and reporting) v63 documents during export."""
+
+    def test_documents_requested_and_skipped_for_v63(self):
+        with patch("lib.services.export_service.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_collection_items.return_value = {
+                "data": [
+                    {"id": 7, "model": "document", "name": "Q3 Report"},
+                    {"id": 100, "model": "card"},
+                ]
+            }
+            mock_client_class.return_value = mock_client
+
+            exporter = ExportService(_make_export_config())
+            with patch.object(exporter, "_export_card_with_dependencies") as mock_export:
+                exporter._process_collection_items(1, "test-path")
+
+            params = mock_client.get_collection_items.call_args[0][1]
+            assert "document" in params["models"]
+            assert exporter._skipped_documents == ["Q3 Report"]
+            assert mock_export.call_count == 1  # the card is still exported
+
+    def test_documents_not_requested_before_v63(self):
+        with patch("lib.services.export_service.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_collection_items.return_value = {"data": []}
+            mock_client_class.return_value = mock_client
+
+            exporter = ExportService(_make_export_config(metabase_version=MetabaseVersion.V56))
+            exporter._process_collection_items(1, "test-path")
+
+            params = mock_client.get_collection_items.call_args[0][1]
+            assert "document" not in params["models"]
+
+
+class TestV63MeasureExport:
+    """Tests for exporting v63 measures into the manifest."""
+
+    def test_export_measures_filters_by_known_tables(self):
+        with patch("lib.services.export_service.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_measures.return_value = [
+                {"id": 5, "name": "Total", "table_id": 27, "definition": {"aggregation": []}},
+                {"id": 6, "name": "Foreign", "table_id": 99, "definition": {}},
+                {"id": 7, "name": "Old", "table_id": 27, "definition": {}, "archived": True},
+            ]
+            mock_client_class.return_value = mock_client
+
+            exporter = ExportService(_make_export_config())
+            exporter.manifest.database_metadata = {
+                1: {"tables": [{"id": 27, "name": "orders", "fields": []}]}
+            }
+            exporter._export_measures()
+
+            assert len(exporter.manifest.measures) == 1
+            assert exporter.manifest.measures[0]["id"] == 5
+            assert exporter.manifest.measures[0]["table_id"] == 27
+
+
+class TestIncludeLibraryParam:
+    """Tests for the --include-library export flag."""
+
+    def _run_export_with(self, config) -> Mock:
+        with patch("lib.services.export_service.MetabaseClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_databases.return_value = []
+            mock_client.get_collections_tree.return_value = []
+            mock_client_class.return_value = mock_client
+
+            exporter = ExportService(config)
+            exporter.run_export()  # returns early: no collections
+            return mock_client
+
+    def test_include_library_passed_for_v63(self, tmp_path):
+        config = _make_export_config(export_dir=str(tmp_path), include_library=True)
+        client = self._run_export_with(config)
+
+        client.get_collections_tree.assert_called_with(params={"include-library": "true"})
+
+    def test_include_library_ignored_before_v63(self, tmp_path):
+        config = _make_export_config(
+            export_dir=str(tmp_path),
+            include_library=True,
+            metabase_version=MetabaseVersion.V58,
+        )
+        client = self._run_export_with(config)
+
+        client.get_collections_tree.assert_called_with()
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch(
+        "sys.argv",
+        [
+            "export_metabase.py",
+            "--source-url",
+            "https://cli.example.com",
+            "--source-username",
+            "cli_user@example.com",
+            "--source-password",
+            "cli_password",
+            "--export-dir",
+            "./cli_export",
+            "--include-library",
+        ],
+    )
+    def test_include_library_cli_flag(self):
+        from lib.config import get_export_args
+
+        config = get_export_args()
+        assert config.include_library is True
+
+
+class TestImportMeasures:
+    """Tests for measure creation and mapping during import."""
+
+    def _make_service(self, tmp_path):
+        config = ImportConfig(
+            target_url="https://target.example.com",
+            export_dir=str(tmp_path),
+            db_map_path="./db_map.json",
+            target_username="test@example.com",
+            target_password="password123",  # pragma: allowlist secret
+            metabase_version=MetabaseVersion.V63,
+        )
+        with patch("lib.services.import_service.MetabaseClient"):
+            service = ImportService(config)
+
+        manifest = _make_manifest({1: "DB1"})
+        manifest.database_metadata = {1: {"tables": [{"id": 27, "name": "orders", "fields": []}]}}
+        manifest.measures = [
+            {
+                "id": 5,
+                "name": "Total",
+                "description": "Sum of totals",
+                "table_id": 27,
+                "definition": {"aggregation": [["sum", ["field", {"lib/uuid": "u"}, 159]]]},
+            }
+        ]
+        service.manifest = manifest
+
+        id_mapper = IDMapper(manifest, DatabaseMap(by_id={"1": 100}))
+        id_mapper._table_map[(1, 27)] = 42
+        id_mapper._field_map[(1, 159)] = 301
+        service._id_mapper = id_mapper
+        service._query_remapper = QueryRemapper(id_mapper)
+        service.client = Mock()
+        return service
+
+    def test_creates_measure_with_remapped_ids(self, tmp_path):
+        service = self._make_service(tmp_path)
+        service.client.get_measures.return_value = []
+        service.client.create_measure.return_value = {"id": 77}
+
+        service._import_measures()
+
+        payload = service.client.create_measure.call_args[0][0]
+        assert payload["name"] == "Total"
+        assert payload["table_id"] == 42
+        assert payload["description"] == "Sum of totals"
+        assert payload["definition"]["aggregation"][0][1][2] == 301
+        assert service._id_mapper.resolve_measure_id(5) == 77
+
+    def test_reuses_existing_target_measure(self, tmp_path):
+        service = self._make_service(tmp_path)
+        service.client.get_measures.return_value = [{"id": 88, "table_id": 42, "name": "Total"}]
+
+        service._import_measures()
+
+        service.client.create_measure.assert_not_called()
+        assert service._id_mapper.resolve_measure_id(5) == 88
+
+    def test_skips_measure_with_unmapped_table(self, tmp_path):
+        service = self._make_service(tmp_path)
+        service._id_mapper._table_map.clear()
+        service.client.get_measures.return_value = []
+
+        service._import_measures()
+
+        service.client.create_measure.assert_not_called()
+        assert service._id_mapper.resolve_measure_id(5) is None
+
+    def test_no_measures_is_a_no_op(self, tmp_path):
+        service = self._make_service(tmp_path)
+        service.manifest.measures = []
+
+        service._import_measures()
+
+        service.client.get_measures.assert_not_called()


### PR DESCRIPTION
> **Note:** This is the upstream twin of [wauk/metabase-migration-toolkit#1](https://github.com/wauk/metabase-migration-toolkit/pull/1). GitHub cannot target a fork's branch from the upstream repo, so the base here is `fix-date-range-environment-mapping` — a mirror of #70's head commit (`9d1582d`) pushed into this repo. The diff is identical: exactly the 7 commits stacked on top of #70. If #70 merges first, this PR can be retargeted to `main`; if this merges into wauk's branch via the fork PR instead, this one can be closed.

## v63 support: fixes for all confirmed gaps from the v0.63.14 audit

This PR stacks on top of your `fix-date-range-environment-mapping` branch and implements every **confirmed** finding from the [v0.63 gap analysis posted on Finverity#70](https://github.com/Finverity/metabase-migration-toolkit/pull/70#issuecomment-5423364753), so your list-form template-tags fix becomes part of complete first-class v63 support instead of requiring the `v58` workaround.

### What's included (7 commits)

1. **`feat: v63 version enum + `V63Adapter`** — `--metabase-version v63` now works end-to-end. The adapter subclasses `V58Adapter` with no endpoint overrides (the v0.63.14 OpenAPI spec confirms every endpoint the toolkit calls is unchanged).
2. **`fix: table template tags, label_field, measure clauses`** —
   - v63 Table Variables (`type: "table"`) carry a raw source `table-id` and `source-filters[].field-id`; both are now remapped (previously imported verbatim → wrong table on the target).
   - `values_source_config.label_field` (v63 "Column to supply the labels") is remapped alongside `value_field`.
   - `["measure", {...}, id]` aggregation references are remapped via a new measure ID map.
   - Bonus hardening of your list-form path: the `next(iter(...))` is now behind a guarded `_remap_single_tag`, so a future change to the dict path can't raise `StopIteration` mid-import.
3. **`fix: preserve dashcard inline_parameters`** — v63 header-/card-level filter placement no longer dropped by the dashcard whitelist rebuild.
4. **`fix: collection permission revocations`** — since 0.56.13 the graph omits `none` entries; absent group/collection pairs are now PUT explicitly as `"none"` so source-side revocations can't become inherited access on the target (Administrators excluded, `root` never synthesized). This one also benefits v57/v58.
5. **`feat: measures + documents + --include-library`** —
   - Measures attached to exported databases are captured into the manifest and recreated before cards (matched by table + name for idempotent re-imports).
   - Documents in v63 collections are counted and warned about during export instead of vanishing silently (full document migration is out of scope here).
   - `--include-library` passes `include-library=true` on `/collection/tree` so the Library (Data Studio) subtree can be exported.
6. **`test: v63 support suite`** — 30 new tests (adapter, table tags dict/list/unmapped, list-form edge cases incl. non-dict entries and duplicate names, measure clause + export/import, label_field, inline_parameters, document detection, include-library, permissions none-fill).
7. **`docs`** — README versions table + v63 notes and flags, CHANGELOG entries under Unreleased.

### Verification

```
pytest -m "not integration"  →  788 passed, 3 skipped
mypy lib/                    →  clean (strict)
ruff check lib/ tests/       →  clean
black --check lib/ tests/    →  clean
```

All 758 pre-existing tests (including your list-form tests) still pass unchanged, except one deliberate adjustment: none — `get_collections_tree()` keeps its no-arg call shape when no params are needed, so the existing archived-param regression test still passes as written.

### Not included (unverified findings from the audit)

MFA session challenge, Transforms, segment-clause remapping, tenant collections/groups, Data Analysts group, transform permission key, verification status, database routing, Remote Sync, Glossary, embed themes — listed in the audit comment; each needs validation against a live v63 instance first.

### Caveat

Everything here is spec- and unit-test-verified against the v0.63.14 OpenAPI spec and docs; it has not yet been run against a live v0.63 instance (no v63 docker-compose in the repo yet). Happy to iterate if you can smoke-test it against your staging migration.
