### PR TITLE
fix: relink dashboard question cards after parent dashboard import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dashboard question `collection_id` mismatch**: Cards created directly within a dashboard
+  ("dashboard questions") were imported with their raw source `dashboard_id`, which points to a
+  dashboard that doesn't exist yet on the target (dashboards import after cards). The target
+  instance rejected the request with `Mismatch detected between Dashboard's collection_id
+  (null) and collection_id (<n>)`. The importer now clears `dashboard_id` on initial card
+  creation/update and relinks the card to its parent dashboard once that dashboard has been
+  imported.
 - **"table" template-tag remapping (v63)**: Table Variables store a raw source table ID
   (`table-id`) and filter field IDs (`source-filters[].field-id`); both are now remapped on
   import instead of being copied verbatim and resolving to the wrong table on the target.
@@ -35,7 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   importer now sends explicit "none" for mapped group/collection pairs absent from the source
   graph, so source-side revocations no longer become inherited access on the target
   (Administrators excluded; the "root" collection is never synthesized).
-
 - **Card parameter value source remapping**: Card filters that source dropdown values from
   another card (`parameters[].values_source_config.card_id`) kept staging card IDs on import,
   causing `parameter_card` foreign key failures. These references are now treated as card

--- a/lib/handlers/card.py
+++ b/lib/handlers/card.py
@@ -99,6 +99,17 @@ class CardHandler(BaseHandler):
             target_collection_id = self.id_mapper.resolve_collection_id(card.collection_id)
             card_data["collection_id"] = target_collection_id
 
+            # Dashboard questions (cards created inside a dashboard) carry a
+            # dashboard_id that must match their parent dashboard's collection_id
+            # on the target. Dashboards are imported after cards, so the parent
+            # dashboard doesn't exist yet - sending the raw source dashboard_id
+            # would reference a non-existent (or wrong) target dashboard and the
+            # target rejects the request with a collection_id mismatch. Strip it
+            # here and relink it once the dashboard has been imported.
+            source_dashboard_id = card_data.get("dashboard_id")
+            if source_dashboard_id is not None:
+                card_data["dashboard_id"] = self.id_mapper.resolve_dashboard_id(source_dashboard_id)
+
             # Handle conflicts using cached collection items lookup
             card_type = card_data.get("type")
             # If card_type is None, all types are searched
@@ -111,6 +122,15 @@ class CardHandler(BaseHandler):
                 self._handle_existing_card(card, card_data, existing_card, target_collection_id)
             else:
                 self._create_card(card, card_data)
+
+            # If the parent dashboard hasn't been imported yet, queue this card for
+            # relinking once DashboardHandler creates/updates that dashboard.
+            if source_dashboard_id is not None and card_data["dashboard_id"] is None:
+                target_card_id = self.id_mapper.resolve_card_id(card.id)
+                if target_card_id is not None:
+                    self.id_mapper.register_pending_dashboard_question(
+                        source_dashboard_id, target_card_id
+                    )
 
         except MetabaseAPIError as e:
             self._handle_api_error(card, e)

--- a/lib/handlers/dashboard.py
+++ b/lib/handlers/dashboard.py
@@ -118,6 +118,9 @@ class DashboardHandler(BaseHandler):
             # Store dashboard ID mapping for click_behavior remapping
             self.id_mapper.set_dashboard_mapping(dash.id, updated_dash["id"])
 
+            # Relink dashboard questions created before this dashboard existed
+            self._relink_pending_dashboard_questions(dash.id, updated_dash["id"])
+
             # Add to collection cache to keep it up-to-date for conflict detection
             if action_taken == "created":
                 self.context.add_to_collection_cache(
@@ -140,6 +143,29 @@ class DashboardHandler(BaseHandler):
                 exc_info=True,
             )
             self._add_report_item("dashboard", "failed", dash.id, None, dash.name, str(e))
+
+    def _relink_pending_dashboard_questions(
+        self, source_dashboard_id: int, target_dashboard_id: int
+    ) -> None:
+        """Relinks dashboard-question cards imported before their parent dashboard.
+
+        Args:
+            source_dashboard_id: The source dashboard ID.
+            target_dashboard_id: The newly created/updated target dashboard ID.
+        """
+        pending_card_ids = self.id_mapper.pop_pending_dashboard_questions(source_dashboard_id)
+        for target_card_id in pending_card_ids:
+            try:
+                self.client.update_card(target_card_id, {"dashboard_id": target_dashboard_id})
+                logger.debug(
+                    f"Relinked dashboard question card {target_card_id} "
+                    f"to dashboard {target_dashboard_id}"
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to relink dashboard question card {target_card_id} "
+                    f"to dashboard {target_dashboard_id}: {e}"
+                )
 
     def _handle_existing_dashboard(
         self,

--- a/lib/remapping/id_mapper.py
+++ b/lib/remapping/id_mapper.py
@@ -39,6 +39,10 @@ class IDMapper:
         self._group_map: dict[int, int] = {}
         self._measure_map: dict[int, int] = {}
 
+        # Dashboard questions whose parent dashboard hasn't been imported yet:
+        # source_dashboard_id -> list of target card IDs awaiting dashboard_id relink
+        self._pending_dashboard_questions: dict[int, list[int]] = {}
+
         # Table and field mappings: (source_db_id, source_id) -> target_id
         self._table_map: dict[tuple[int, int], int] = {}
         self._field_map: dict[tuple[int, int], int] = {}
@@ -198,6 +202,32 @@ class IDMapper:
             The target dashboard ID, or None if not mapped.
         """
         return self._dashboard_map.get(source_dashboard_id)
+
+    def register_pending_dashboard_question(
+        self, source_dashboard_id: int, target_card_id: int
+    ) -> None:
+        """Registers a dashboard-question card awaiting its parent dashboard.
+
+        Dashboard questions (cards created inside a dashboard) must have their
+        `dashboard_id` relinked once the parent dashboard has been imported,
+        since dashboards are imported after cards.
+
+        Args:
+            source_dashboard_id: The source dashboard ID the card belongs to.
+            target_card_id: The target card ID to relink once possible.
+        """
+        self._pending_dashboard_questions.setdefault(source_dashboard_id, []).append(target_card_id)
+
+    def pop_pending_dashboard_questions(self, source_dashboard_id: int) -> list[int]:
+        """Returns and clears target card IDs awaiting relink to this dashboard.
+
+        Args:
+            source_dashboard_id: The source dashboard ID.
+
+        Returns:
+            List of target card IDs to relink, empty if none are pending.
+        """
+        return self._pending_dashboard_questions.pop(source_dashboard_id, [])
 
     # --- Build table and field mappings ---
 

--- a/tests/test_card_handler.py
+++ b/tests/test_card_handler.py
@@ -990,6 +990,87 @@ class TestImportSingleCard:
         # Should report failure
         import_context.report.add.assert_called()
 
+    def test_import_dashboard_question_strips_unmapped_dashboard_id(
+        self, import_context, mock_client, mock_id_mapper, mock_query_remapper, tmp_path
+    ):
+        """Dashboard-question cards must not send a stale source dashboard_id.
+
+        Regression test for the collection_id mismatch error raised by the target
+        instance when a dashboard question's dashboard hasn't been imported yet.
+        """
+        card_file = tmp_path / "test_card.json"
+        card_file.write_text(
+            json.dumps(
+                {
+                    "name": "Test Card",
+                    "dataset_query": {"query": {"source-table": 10}, "database": 1},
+                    "dashboard_id": 55,
+                }
+            )
+        )
+
+        # Pass card data through unchanged so dashboard_id survives remapping
+        mock_query_remapper.remap_card_data.side_effect = lambda data, cards: (data, True)
+        mock_id_mapper.resolve_dashboard_id.return_value = None  # Dashboard not imported yet
+        mock_client.get_collection_items.return_value = {"data": []}
+        mock_client.create_card.return_value = {"id": 1000, "name": "Test Card"}
+        mock_id_mapper.resolve_card_id.return_value = 1000  # Newly created card's target ID
+
+        handler = CardHandler(import_context)
+        card = Card(
+            id=1,
+            name="Test Card",
+            file_path="test_card.json",
+            collection_id=10,
+            database_id=1,
+            archived=False,
+            dataset=False,
+        )
+
+        handler._import_single_card(card)
+
+        created_payload = mock_client.create_card.call_args[0][0]
+        assert created_payload["dashboard_id"] is None
+        mock_id_mapper.register_pending_dashboard_question.assert_called_once_with(55, 1000)
+
+    def test_import_dashboard_question_uses_mapped_dashboard_id(
+        self, import_context, mock_client, mock_id_mapper, mock_query_remapper, tmp_path
+    ):
+        """If the parent dashboard was already imported, use its mapped target ID."""
+        card_file = tmp_path / "test_card.json"
+        card_file.write_text(
+            json.dumps(
+                {
+                    "name": "Test Card",
+                    "dataset_query": {"query": {"source-table": 10}, "database": 1},
+                    "dashboard_id": 55,
+                }
+            )
+        )
+
+        mock_query_remapper.remap_card_data.side_effect = lambda data, cards: (data, True)
+        mock_id_mapper.resolve_dashboard_id.return_value = 555  # Already mapped
+        mock_client.get_collection_items.return_value = {"data": []}
+        mock_client.create_card.return_value = {"id": 1000, "name": "Test Card"}
+        mock_id_mapper.resolve_card_id.return_value = 1000
+
+        handler = CardHandler(import_context)
+        card = Card(
+            id=1,
+            name="Test Card",
+            file_path="test_card.json",
+            collection_id=10,
+            database_id=1,
+            archived=False,
+            dataset=False,
+        )
+
+        handler._import_single_card(card)
+
+        created_payload = mock_client.create_card.call_args[0][0]
+        assert created_payload["dashboard_id"] == 555
+        mock_id_mapper.register_pending_dashboard_question.assert_not_called()
+
 
 class TestMetricCardConflictResolution:
     """Tests that metric and question cards with the same name don't collide."""
@@ -1158,3 +1239,29 @@ class TestImportCards:
 
             # Should import both cards
             assert mock_import.call_count == 2
+
+
+class TestIDMapperPendingDashboardQuestions:
+    """Tests for IDMapper's dashboard-question relink registry."""
+
+    @pytest.fixture
+    def id_mapper(self):
+        """Create a real IDMapper instance."""
+        from lib.models_core import DatabaseMap
+
+        manifest = Mock(spec=Manifest)
+        manifest.databases = {}
+        return IDMapper(manifest=manifest, db_map=DatabaseMap())
+
+    def test_register_and_pop_pending_dashboard_question(self, id_mapper):
+        """Registered cards are returned once, then the queue is cleared."""
+        id_mapper.register_pending_dashboard_question(55, 1000)
+        id_mapper.register_pending_dashboard_question(55, 1001)
+
+        assert id_mapper.pop_pending_dashboard_questions(55) == [1000, 1001]
+        # Popping again returns an empty list (already cleared)
+        assert id_mapper.pop_pending_dashboard_questions(55) == []
+
+    def test_pop_pending_dashboard_questions_none_registered(self, id_mapper):
+        """Popping with no registrations returns an empty list."""
+        assert id_mapper.pop_pending_dashboard_questions(99) == []

--- a/tests/test_dashboard_handler.py
+++ b/tests/test_dashboard_handler.py
@@ -1058,6 +1058,80 @@ class TestImportSingleDashboard:
         # Should report failure
         import_context.report.add.assert_called()
 
+    def test_import_dashboard_relinks_pending_dashboard_questions(
+        self, import_context, mock_client, mock_id_mapper, tmp_path
+    ):
+        """Cards created before their parent dashboard must be relinked afterwards."""
+        dash_file = tmp_path / "test_dashboard.json"
+        dash_file.write_text(
+            json.dumps(
+                {
+                    "name": "Test Dashboard",
+                    "description": "A test dashboard",
+                    "collection_id": 10,
+                    "parameters": [],
+                    "dashcards": [],
+                }
+            )
+        )
+
+        mock_client.get_collection_items.return_value = {"data": []}
+        mock_client.create_dashboard.return_value = {"id": 1000, "name": "Test Dashboard"}
+        mock_client.update_dashboard.return_value = {"id": 1000, "name": "Test Dashboard"}
+        mock_id_mapper.pop_pending_dashboard_questions.return_value = [2000, 2001]
+
+        handler = DashboardHandler(import_context)
+        dash = Dashboard(
+            id=1,
+            name="Test Dashboard",
+            file_path="test_dashboard.json",
+            collection_id=10,
+            archived=False,
+        )
+
+        handler._import_single_dashboard(dash)
+
+        mock_id_mapper.pop_pending_dashboard_questions.assert_called_once_with(1)
+        mock_client.update_card.assert_any_call(2000, {"dashboard_id": 1000})
+        mock_client.update_card.assert_any_call(2001, {"dashboard_id": 1000})
+
+    def test_import_dashboard_relink_failure_does_not_fail_import(
+        self, import_context, mock_client, mock_id_mapper, tmp_path
+    ):
+        """A relink failure should be logged, not fail the whole dashboard import."""
+        dash_file = tmp_path / "test_dashboard.json"
+        dash_file.write_text(
+            json.dumps(
+                {
+                    "name": "Test Dashboard",
+                    "collection_id": 10,
+                    "parameters": [],
+                    "dashcards": [],
+                }
+            )
+        )
+
+        mock_client.get_collection_items.return_value = {"data": []}
+        mock_client.create_dashboard.return_value = {"id": 1000, "name": "Test Dashboard"}
+        mock_client.update_dashboard.return_value = {"id": 1000, "name": "Test Dashboard"}
+        mock_id_mapper.pop_pending_dashboard_questions.return_value = [2000]
+        mock_client.update_card.side_effect = Exception("API Error")
+
+        handler = DashboardHandler(import_context)
+        dash = Dashboard(
+            id=1,
+            name="Test Dashboard",
+            file_path="test_dashboard.json",
+            collection_id=10,
+            archived=False,
+        )
+
+        handler._import_single_dashboard(dash)
+
+        # Dashboard import itself should still be reported as successful
+        report_call = import_context.report.add.call_args[0][0]
+        assert report_call.status == "created"
+
 
 class TestImportDashboards:
     """Tests for importing multiple dashboards."""


### PR DESCRIPTION
> **Note:** This PR is based on `fix-date-range-environment-mapping` (PR #72's head, `66be326`)
> rather than `main`, because that branch isn't merged yet and this fix builds cleanly on top of
> it. The diff is a single commit (`8935ae0`) on top of #72's 9 commits. Once #72 merges into
> `main`, this can be retargeted there — the fix itself is independent of the v63 work.

# Pull Request

## Description

Cards created directly inside a dashboard ("dashboard questions") failed to import with:

```
Mismatch detected between Dashboard's collection_id (null) and collection_id (<n>)
```

The importer sent the card's raw source `dashboard_id` unchanged, but dashboards import
**after** cards in the dependency order, so the target dashboard doesn't exist yet at
card-creation time — Metabase rejects the mismatched `collection_id`/`dashboard_id` pair.

This PR resolves `dashboard_id` through the ID mapper when available, strips it when the
target dashboard doesn't exist yet, and relinks the card to its parent dashboard once that
dashboard has actually been created.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes: dashboard-question import failure surfaced during a live migration to a v0.63.5
target instance (`Mismatch detected between Dashboard's collection_id ... and collection_id`). #71 

## Changes Made

- `lib/remapping/id_mapper.py`: Added a pending-relink registry
  (`register_pending_dashboard_question` / `pop_pending_dashboard_questions`) that tracks
  dashboard-question cards whose target dashboard doesn't exist yet at import time.
- `lib/handlers/card.py`: On import, resolves the card's source `dashboard_id` through the ID
  mapper; if the target dashboard isn't mapped yet, clears `dashboard_id` on
  create/update and registers the card for relinking.
- `lib/handlers/dashboard.py`: After a dashboard is created/mapped, pops any pending
  dashboard-question cards for it and `PUT`s their `dashboard_id` to the new target ID (a
  relink failure is logged as a warning and does not fail the overall import).
- `CHANGELOG.md`: Added an entry under `Unreleased`.
- Tests: 4 new tests in `tests/test_card_handler.py` (dashboard_id stripping/resolution,
  pending-registry register/pop) and 2 new tests in `tests/test_dashboard_handler.py`
  (relink-on-import, relink-failure-is-non-fatal).

## Testing

### Test Configuration

- Python version: 3.12.11
- Operating System: Windows
- Metabase version (if applicable): v0.63.5 (also exercised the existing v56/v57/v58 suites)

### Test Results

- [x] All existing tests pass
- [x] New tests added and passing
- [x] Manual testing completed

### Test Commands Run

```bash
pytest -o addopts="" -q -m "not integration"
# 793 passed, 3 skipped, 78 deselected
# (1 pre-existing, unrelated Windows-only flaky failure in
#  test_error_handling.py::test_write_to_readonly_directory — chmod(0o444) doesn't
#  actually deny the owning process write access on NTFS; confirmed pre-existing on
#  upstream/main, not introduced by this change)

black --check --diff .        # all done, no changes
ruff check .                  # all clean
isort --profile black --check-only --diff .   # 3 pre-existing failures, confirmed
                                                # identical to upstream/main, unrelated to this PR
mypy --ignore-missing-imports lib   # Success: no issues found in 26 source files

pytest --cov=lib --cov-report=term-missing -q -m "not integration"
# TOTAL coverage: 86.61% (3268 stmts, 1108 branches)
# Required test coverage of 85.0% reached.
```

Manually verified against a live v0.63.5 target: re-ran the migration that originally
triggered the bug and confirmed `dashboard_id` is now `null` in the create payload (no more
`collection_id` mismatch), with the dashboard question correctly relinked after import.

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] I have updated the CHANGELOG.md file
- [x] I have checked my code with black, ruff, and mypy

## Breaking Changes

None / N/A

## Migration Guide

N/A

## Additional Notes

This fix is orthogonal to the v63 work in #72 — it applies to any Metabase version where
dashboards import after cards (v56/v57/v58/v63 alike). It's based on top of
`fix-date-range-environment-mapping` purely so it can be tested and merged without waiting
on #72, not because it depends on any v63-specific behavior.

## Code Quality

```bash
black lib/ tests/ *.py
ruff check lib/ tests/ *.py
mypy lib/
pytest --cov=lib
```

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the MIT License.**
