### PR TITLE
fix(dashboard): preserve static embedding configuration

### DIFF
--- a/lib/handlers/dashboard.py
+++ b/lib/handlers/dashboard.py
@@ -584,6 +584,12 @@ class DashboardHandler(BaseHandler):
         if "auto_apply_filters" in payload:
             update_payload["auto_apply_filters"] = payload["auto_apply_filters"]
 
+        # Preserve static embedding configuration without silently disabling it.
+        if payload.get("enable_embedding"):
+            update_payload["enable_embedding"] = True
+            if "embedding_params" in payload:
+                update_payload["embedding_params"] = payload["embedding_params"]
+
         # Add tabs if any (must be sent together with dashcards in v57)
         if tabs:
             update_payload["tabs"] = tabs

--- a/tests/test_dashboard_handler.py
+++ b/tests/test_dashboard_handler.py
@@ -944,6 +944,20 @@ class TestBuildUpdatePayload:
         assert result["width"] == "full"
         assert result["auto_apply_filters"] is True
 
+    def test_build_update_payload_with_embedding_configuration(self, import_context):
+        """Test that enabled static embedding configuration is preserved."""
+        handler = DashboardHandler(import_context)
+        embedding_params = {"locked": True}
+        payload = {
+            "enable_embedding": True,
+            "embedding_params": embedding_params,
+        }
+
+        result = handler._build_update_payload("Test", payload, [], [])
+
+        assert result["enable_embedding"] is True
+        assert result["embedding_params"] == embedding_params
+
     def test_build_update_payload_removes_none_values(self, import_context):
         """Test that None values are removed from payload."""
         handler = DashboardHandler(import_context)


### PR DESCRIPTION
## Description

Fixes #75 by preserving static embedding configuration when importing an enabled dashboard.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD improvement

## Related Issues

Fixes #75

## Changes Made

- Include `enable_embedding` in the dashboard update payload when static embedding is enabled.
- Preserve the source dashboard's `embedding_params` in the same update payload.
- Add a unit regression test for the enabled embedding configuration.

The implementation intentionally does not send `enable_embedding: false`, so an existing target dashboard is not silently unpublished.

## Testing

### Test Configuration

- Python version: 3.12.7
- Operating System: Windows
- Metabase version (if applicable): Not applicable; unit tests mock the API client.

### Test Results

- [ ] All existing tests pass — one unrelated Windows-only read-only directory test fails because Windows permits the write in this environment; 794 other non-integration tests pass.
- [x] New tests added and passing
- [ ] Manual testing completed — not applicable; no live Metabase instance was used.

### Test Commands Run

```bash
python -m pytest tests/test_dashboard_handler.py -k "build_update_payload" --no-cov --basetemp <workspace>/pytest-tmp
# 5 passed

python -m pytest -m "not integration" --basetemp <workspace>/pytest-tmp
# 794 passed, 3 skipped, 1 unrelated environment-specific failure

python -m black --check lib/ tests/ *.py
# passed

python -m ruff check lib/ tests/ *.py
# passed

python -m mypy lib/ --ignore-missing-imports
# Success: no issues found in 26 source files
```

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — the change is self-explanatory and covered by the existing method structure.
- [ ] I have made corresponding changes to the documentation — not needed for this bug fix.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally — see the unrelated Windows permission failure above.
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file — not needed for this focused bug fix.
- [x] I have checked my code with black, ruff, and mypy

## Breaking Changes

None.

## Migration Guide

Not applicable.

## Additional Notes

The update payload remains unchanged for dashboards without enabled static embedding and for all unfiltered dashboard fields.

## Code Quality

Black, Ruff, and Mypy commands listed above passed.

**By submitting this pull request, I confirm that my contribution is made under the terms of the MIT License.**
